### PR TITLE
Auto-Gen Config Files with Backwards Compatibility v2 v2.1 v3 LeRobot Codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,80 +1,220 @@
 # lerobot2mcap
 
-Convert LeRobot datasets to MCAP format. The config file is automatically generated from your dataset metadata - no manual setup required.
+Convert LeRobot datasets to MCAP format with automatic configuration generation from dataset metadata. No manual configuration required - just point it at your dataset and go.
 
 ## Features
 
-- **Automatic configuration**: Reads `meta/info.json` and generates all necessary configuration
+- **Automatic configuration**: Reads `meta/info.json` and generates all necessary configuration using Pydantic models for type safety
 - **Episode-based conversion**: Converts each episode to a separate MCAP file in its own directory
-- **Chunk-aware**: Handles datasets organized in chunks, ready for multi-chunk datasets
-- **Multi-video support**: Auto-detects and converts all video streams
+- **Chunk-aware**: Handles datasets organized in chunks (supports datasets with 1000+ episodes)
+- **Multi-video support**: Auto-detects and converts all video streams with codec validation
 - **Terminal log support**: Parses raw `.log` files into `rcl_interfaces/msg/Log` messages with full metadata
-- **ROS2 format**: Outputs ROS2-compatible MCAP files
+- **ROS2 format**: Outputs ROS2-compatible MCAP files (configurable via metadata)
 - **Cross-compatible**: Supports LeRobot v2.0, v2.1, and v3 dataset formats automatically
+- **Metadata-driven**: Reads FPS, video codecs, writer format, and chunk size from dataset metadata
+
+## Installation
+
+### Using uv (Recommended)
+
+```bash
+# Clone the repository
+git clone https://github.com/yourusername/lerobot2mcap.git
+cd lerobot2mcap
+
+# Install dependencies
+uv sync
+
+# Open help menu
+uv run lerobot2mcap --help
+```
+
+### Using pip
+
+```bash
+# Clone and install
+git clone https://github.com/yourusername/lerobot2mcap.git
+cd lerobot2mcap
+pip install -e .
+```
+
+## Requirements
+
+Your LeRobot dataset must have the following structure:
+
+```
+dataset_root/
+├── meta/
+│   └── info.json          # Required: Dataset metadata
+├── data/                  # Required: Parquet data files
+└── videos/                # Optional: Video files (if dataset contains video)
+```
+
+### Required `info.json` Fields
+
+The converter reads the following fields from `meta/info.json`:
+
+| Field | Type | Description | Default |
+|-------|------|-------------|---------|
+| `codebase_version` | string | Dataset format version (e.g., "v2.0", "v3.0") | *(required)* |
+| `total_episodes` | int | Total number of episodes in the dataset | *(required)* |
+| `fps` | int | Frames per second for the dataset | *(required)* |
+| `features` | dict | Feature definitions including video streams and their codecs | *(required)* |
+| `data_path` | string | Template path for parquet files | *(required)* |
+| `video_path` | string | Template path for video files | *(required if videos exist)* |
+| `chunks_size` | int | Maximum episodes per chunk | 1000 |
+| `writer_format` | string | MCAP writer format ("ros1", "ros2", "json", "protobuf") | "ros2" |
+
+### Video Codec Support
+
+Video codecs are read from the `features` section of `info.json`. Supported formats:
+- `h264` (default)
+- `h265`
+- `vp9`
+- `av1`
 
 ## Architecture
 
-The converter uses an object-oriented architecture:
+The converter uses an object-oriented, metadata-driven architecture:
 
-- **DatasetInfo**: Parses `meta/info.json` to extract dataset structure (FPS, video streams, codecs, episodes, chunks)
-- **ConfigGenerator**: Automatically generates episode-specific configurations from dataset metadata
-- **LeRobotConverter**: Orchestrates the conversion process, iterating through chunks and episodes
-- Uses **tabular2mcap** under the hood for MCAP writing
+```
+┌─────────────────┐
+│  DatasetInfo    │  Parses meta/info.json to extract:
+│                 │  • total_episodes, chunks_size, fps
+└────────┬────────┘  • video_keys and codecs from features
+         │           • data_path and video_path templates
+         │           • codebase_version, writer_format
+         ↓
+┌─────────────────┐
+│ ConfigGenerator │  Generates per-episode Pydantic configs:
+│                 │  • TabularMappingConfig (parquet data)
+└────────┬────────┘  • CompressedVideoMappingConfig (videos)
+         │           • AttachmentConfig (log files)
+         │           • Validates all fields at runtime
+         ↓
+┌─────────────────┐
+│ LeRobotConverter│  Orchestrates conversion:
+│                 │  • Iterates through episodes
+└────────┬────────┘  • Calls tabular2mcap per episode
+         │           • Saves config alongside MCAP
+         ↓
+┌─────────────────┐
+│  tabular2mcap   │  Performs actual MCAP writing:
+│                 │  • Reads parquet, videos, logs
+└─────────────────┘  • Writes MCAP with ROS2 schemas
+```
 
-The converter processes datasets by iterating through each chunk and converting all episodes within that chunk to separate MCAP files.
+**Key Design Principles:**
+1. **Type Safety**: Uses Pydantic models from `tabular2mcap.loader.models` for validation
+2. **Template-Based**: Builds configs from a base template with `.model_copy()`
+3. **Metadata-Driven**: Reads all values from `info.json` instead of hardcoding
+4. **Episode-Level**: Processes one episode at a time for predictable output structure
 
 ## Usage
 
-### Download Dataset
+The tool provides two main commands: `download` and `convert`.
 
-If you wish to use an existing dataset offered by Hugging Face, use the following commands.
+### Quick Start
 
 ```bash
-# Download from Hugging Face
+# Download and convert in one command (downloads from Hugging Face)
 uv run lerobot2mcap download lerobot/pusht -o ./data
 
-# Download specific episodes
-uv run lerobot2mcap download lerobot/pusht -o ./data -e 0 1 2
+# Or convert an existing dataset
+uv run lerobot2mcap convert ~/.cache/huggingface/lerobot/pusht -o ./mcap_output
 ```
 
-### Record Your Own Dataset With a .log File
-If you wish to record a regular dataset without the additional .log file, HuggingFace's tutorials have that covered. To record a dataset while capturing the terminal output, use the following command:
+### Command: `download`
+
+Download LeRobot datasets from Hugging Face Hub. The dataset will be downloaded and then automatically converted to MCAP.
 
 ```bash
-LOG_FILE=~/.cache/huggingface/lerobot/${HF_USER}/record-test.log
+# Download full dataset
+uv run lerobot2mcap download lerobot/pusht -o ./data
+
+# Download specific episodes only
+uv run lerobot2mcap download lerobot/pusht -o ./data -e 0 1 2
+
+# Without output dir (defaults to ./data)
+uv run lerobot2mcap download lerobot/pusht
+```
+
+**Arguments:**
+- `dataset_id`: Hugging Face dataset ID (e.g., `lerobot/pusht`)
+- `-o, --output-dir`: Output directory (default: `./data`)
+- `-e, --episodes`: Specific episode indices to download (default: all episodes)
+
+**Output:**
+- Downloads dataset to `<output-dir>/`
+- Creates MCAP files in `<output-dir>/mcap_conversion/`
+
+### Command: `convert`
+
+Convert an existing LeRobot dataset to MCAP format.
+
+```bash
+# Convert all episodes (configuration auto-generated)
+uv run lerobot2mcap convert ~/.cache/huggingface/lerobot/pusht -o ./mcap_output
+
+# Convert specific episodes only
+uv run lerobot2mcap convert /path/to/dataset -o ./mcap_output -e 0 1 2
+
+# Custom converter functions (advanced)
+uv run lerobot2mcap convert /path/to/dataset -o ./mcap_output -f ./my_converter_functions.yaml
+```
+
+**Arguments:**
+- `input_dir`: Path to LeRobot dataset root (must contain `meta/info.json`)
+- `-o, --output-dir`: Output directory for MCAP files (default: `<input_dir>/mcap_conversion`)
+- `-e, --episodes`: Specific episode indices to convert (default: all episodes)
+- `-f, --converter-functions`: Path to custom converter functions YAML (default: built-in `configs/converter_functions.yaml`)
+
+**What Happens During Conversion:**
+1. Reads `meta/info.json` to understand dataset structure
+2. Calculates total chunks: `ceil(total_episodes / chunks_size)`
+3. For each episode:
+   - Generates Pydantic config with file paths
+   - Validates config fields
+   - Calls `tabular2mcap` to create MCAP
+   - Saves both MCAP and config YAML
+4. Skips episodes with missing files (warns in logs)
+
+### Recording Your Own Dataset With Terminal Logs
+
+To capture terminal logs during recording (optional but recommended for debugging):
+
+```bash
+# Set log file path
+LOG_FILE=~/.cache/huggingface/lerobot/${HF_USER}/my-dataset.log
+
+# Record with lerobot-record and capture terminal output
 lerobot-record \
     --robot.type=so101_follower \
     --robot.port=/dev/tty.usbmodem5A680114161 \
-    --robot.id=my_awesome_follower_arm \
-    --robot.cameras="{ 
-    front: {type: opencv, index_or_path: 0, width: 1920, height: 1080, fps: 30},
-    external: {type: opencv, index_or_path: 1, width: 640, height: 480, fps: 15}     
+    --robot.id=my_follower_arm \
+    --robot.cameras="{
+        front: {type: opencv, index_or_path: 0, width: 1920, height: 1080, fps: 30},
+        external: {type: opencv, index_or_path: 1, width: 640, height: 480, fps: 15}
     }" \
     --teleop.type=so101_leader \
     --teleop.port=/dev/tty.usbmodem5A680123701 \
-    --teleop.id=my_awesome_leader_arm \
+    --teleop.id=my_leader_arm \
     --display_data=true \
-    --dataset.repo_id=${HF_USER}/record-test
+    --dataset.repo_id=${HF_USER}/my-dataset \
     --dataset.episode_time_s=60 \
     --dataset.reset_time_s=0 \
-    --dataset.num_episodes=1 \
-    --dataset.single_task="recording edge cases" \
+    --dataset.num_episodes=10 \
+    --dataset.single_task="Pick and place demo" \
     2>&1 | tee $LOG_FILE
 
+# Move log file to dataset root for automatic inclusion
+mv $LOG_FILE ~/.cache/huggingface/lerobot/${HF_USER}/my-dataset/recording.log
 ```
 
-### Convert to MCAP
-
-```bash
-# Convert all episodes from all chunks (configuration generated automatically)
-uv run lerobot2mcap convert ~/.cache/huggingface/lerobot/{repo-id} -o ./mcap_output
-
-# Convert specific episodes
-uv run lerobot2mcap convert ~/.cache/huggingface/lerobot/{repo-id} -o ./mcap_output -e 0 1 2
-
-# Advanced: Custom converter functions (optional)
-uv run lerobot2mcap convert ~/.cache/huggingface/lerobot/{repo-id} -o ./mcap_output -f ./my_converter_functions.yaml
-```
+**Note:** Place the `.log` file in the dataset root directory. The converter will automatically:
+- Detect it using `**/*.log` pattern
+- Parse it into `rcl_interfaces/msg/Log` messages
+- Include it as an attachment in the MCAP file
 
 ### Expected Dataset Structure
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Convert LeRobot datasets to MCAP format with automatic configuration generation 
 - **Automatic configuration**: Reads `meta/info.json` and generates all necessary configuration using Pydantic models for type safety
 - **Episode-based conversion**: Converts each episode to a separate MCAP file in its own directory
 - **Chunk-aware**: Handles datasets organized in chunks (supports datasets with 1000+ episodes)
-- **Multi-video support**: Auto-detects and converts all video streams with codec validation
+- **Multi-video support**: Auto-detects and converts all video streams
 - **Terminal log support**: Parses raw `.log` files into `rcl_interfaces/msg/Log` messages with full metadata
 - **ROS2 format**: Outputs ROS2-compatible MCAP files (configurable via metadata)
-- **Cross-compatible**: Supports LeRobot v2.0, v2.1, and v3 dataset formats automatically
+- **Cross-compatible**: Supports LeRobot v2.0, v2.1 dataset formats automatically, with partial support for v3.0
 - **Metadata-driven**: Reads FPS, video codecs, writer format, and chunk size from dataset metadata
 
 ## Installation
@@ -40,7 +40,7 @@ pip install -e .
 
 ## Requirements
 
-Your LeRobot dataset must have the following structure:
+Your LeRobot dataset should have the following structure:
 
 ```
 dataset_root/
@@ -67,11 +67,7 @@ The converter reads the following fields from `meta/info.json`:
 
 ### Video Codec Support
 
-Video codecs are read from the `features` section of `info.json`. Supported formats:
-- `h264` (default)
-- `h265`
-- `vp9`
-- `av1`
+The converter uses the h264 video codec. If another codec is desired this can be done by changing `DEFAULT_CODEC` in `dataset_info.py`.
 
 ## Architecture
 
@@ -218,11 +214,11 @@ mv $LOG_FILE ~/.cache/huggingface/lerobot/${HF_USER}/my-dataset/recording.log
 
 ### Expected Dataset Structure
 
-The converter automatically detects and supports both LeRobot v2.0, v2.1, and v3 dataset formats. Example input file structures are given below for v3 and v2.1 (very similar to v2). 
+The converter automatically detects and supports both LeRobot v2.0, v2.1 dataset formats, and has partial support for the v3 dataset format. Example input file structures are given below for v3 and v2.1 (very similar to v2). 
 
 #### LeRobot v3 Format
 
-Multiple episodes will be concatenated into the same files, based on episode and MP4 file size limits defined in the lerobot codebase. The following file structure is an example only; the method and conditions, and recording parameters that data is collected with will dicate how many episodes are merged per file.  
+Im Lerobot dataset v3.0 multiple episodes are concatenated into the same files, based on episode and MP4 file size limits defined in the lerobot codebase. The following file structure is an example only; the method and conditions, and recording parameters that data is collected with will dicate how many episodes are merged per file. It should be noted that the seperation of these files back into seperate episodes is not yet supported.
 ```
 dataset_root/
 ├── meta/
@@ -338,6 +334,10 @@ functions:
 ```
 
 **Note**: Log parsing is handled automatically by tabular2mcap's `LogConverter` - no converter function needed.
+
+## Future Work 
+Lerobot dataset v3.0 file splitting into individual episodes is yet to be added to this repository. 
+
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Convert LeRobot datasets to MCAP format. The config file is automatically genera
 ## Features
 
 - **Automatic configuration**: Reads `meta/info.json` and generates all necessary configuration
-- **Chunk-based conversion**: Converts LeRobot datasets organized in chunks
+- **Episode-based conversion**: Converts each episode to a separate MCAP file in its own directory
+- **Chunk-aware**: Handles datasets organized in chunks, ready for multi-chunk datasets
 - **Multi-video support**: Auto-detects and converts all video streams
 - **Terminal log support**: Parses raw `.log` files into `rcl_interfaces/msg/Log` messages with full metadata
 - **ROS2 format**: Outputs ROS2-compatible MCAP files
@@ -14,10 +15,12 @@ Convert LeRobot datasets to MCAP format. The config file is automatically genera
 
 The converter uses an object-oriented architecture:
 
-- **DatasetInfo**: Parses `meta/info.json` to extract dataset structure (FPS, video streams, codecs, etc.)
-- **ConfigGenerator**: Automatically generates configuration from dataset metadata
-- **LeRobotConverter**: Orchestrates the conversion process
+- **DatasetInfo**: Parses `meta/info.json` to extract dataset structure (FPS, video streams, codecs, episodes, chunks)
+- **ConfigGenerator**: Automatically generates episode-specific configurations from dataset metadata
+- **LeRobotConverter**: Orchestrates the conversion process, iterating through chunks and episodes
 - Uses **tabular2mcap** under the hood for MCAP writing
+
+The converter processes datasets by iterating through each chunk and converting all episodes within that chunk to separate MCAP files.
 
 ## Usage
 
@@ -36,11 +39,17 @@ uv run lerobot2mcap download lerobot/pusht -o ./data -e 0 1 2
 ### Convert to MCAP
 
 ```bash
-# Convert all chunks (configuration generated automatically)
+# Convert all episodes from all chunks (configuration generated automatically)
 uv run lerobot2mcap convert ~/.cache/huggingface/lerobot/{repo-id} -o ./mcap_output
 
-# Convert specific chunks
+# Convert specific episodes
+uv run lerobot2mcap convert ~/.cache/huggingface/lerobot/{repo-id} -o ./mcap_output -e 0 1 2
+
+# Convert specific chunks (for multi-chunk datasets)
 uv run lerobot2mcap convert ~/.cache/huggingface/lerobot/{repo-id} -o ./mcap_output -c 0 1
+
+# Combine: specific episodes from specific chunks
+uv run lerobot2mcap convert ~/.cache/huggingface/lerobot/{repo-id} -o ./mcap_output -c 0 -e 0 1 2
 
 # Advanced: Custom converter functions (optional)
 uv run lerobot2mcap convert ~/.cache/huggingface/lerobot/{repo-id} -o ./mcap_output -f ./my_converter_functions.yaml
@@ -48,29 +57,54 @@ uv run lerobot2mcap convert ~/.cache/huggingface/lerobot/{repo-id} -o ./mcap_out
 
 ### Expected Dataset Structure
 
-Video file structure is an example only. Depending on hardware setup subfile names may change
+Video file structure is an example only. Depending on hardware setup subfile names may change.
+
+Each episode is represented as a separate file (file-000, file-001, file-002, etc.) within a chunk.
 
 ```
 dataset_root/
 ├── meta/
-│   └── info.json           # Dataset metadata
+│   ├── info.json           # Dataset metadata (includes total_episodes)
+│   ├── episodes.jsonl
+│   └── tasks.jsonl
 ├── data/
 │   └── chunk-000/
-│       └── file-000.parquet
+│       ├── file-000.parquet  # Episode 0
+│       ├── file-001.parquet  # Episode 1
+│       └── file-002.parquet  # Episode 2
 ├── videos/
 │   ├── observation.images.front/
 │   │   └── chunk-000/
-│   │       └── file-000.mp4
+│   │       ├── file-000.mp4  # Episode 0
+│   │       ├── file-001.mp4  # Episode 1
+│   │       └── file-002.mp4  # Episode 2
 │   └── observation.images.external/
 │       └── chunk-000/
-│           └── file-000.mp4
+│           ├── file-000.mp4  # Episode 0
+│           ├── file-001.mp4  # Episode 1
+│           └── file-002.mp4  # Episode 2
 └── recording.log           # Optional terminal log
 ```
 
 ## Output
 
-Each chunk produces one MCAP file with:
-- **Robot data** from parquet files (topic: `robot_data`)
+Each episode produces a separate directory containing an MCAP file and its configuration:
+
+```
+mcap_output/
+├── episode_000/
+│   ├── episode_000.mcap
+│   └── config_000.yaml
+├── episode_001/
+│   ├── episode_001.mcap
+│   └── config_001.yaml
+└── episode_002/
+    ├── episode_002.mcap
+    └── config_002.yaml
+```
+
+Each MCAP file contains:
+- **Robot data** from the episode's parquet file (topic: `robot_data`)
 - **Video streams** for each camera (topics: `observation/images/front`, `observation/images/external`, etc.)
 - **Terminal logs** as `rcl_interfaces/msg/Log` if `.log` files present (topic: `terminal_log`)
   - Includes full metadata: log level, timestamp, source file, line number, and message
@@ -81,16 +115,18 @@ Each chunk produces one MCAP file with:
 **You don't need to create any configuration files** - everything is automatic:
 
 1. **DatasetInfo** reads your `meta/info.json` to discover:
+   - Total number of episodes
    - Video streams and their codecs
    - Dataset FPS and structure
    - Data file patterns
 
-2. **ConfigGenerator** creates a config for each chunk:
-   - Tabular mappings for parquet files
-   - Video mappings for each camera stream
+2. **ConfigGenerator** creates a config for each episode:
+   - Tabular mappings pointing to the specific episode's parquet file
+   - Video mappings pointing to the specific episode's video files
    - Log mappings if `.log` files are present
+   - Each config is saved alongside its MCAP file for transparency
 
-3. **tabular2mcap** uses this generated config to convert to MCAP
+3. **tabular2mcap** uses each generated config to convert the episode to MCAP
 
 ### Advanced: Custom Converter Functions (Optional)
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,130 @@
 # lerobot2mcap
 
-Convert LeRobot datasets to MCAP format.
+Convert LeRobot datasets to MCAP format. The config file is automatically generated from your dataset metadata - no manual setup required.
+
+## Features
+
+- **Automatic configuration**: Reads `meta/info.json` and generates all necessary configuration
+- **Chunk-based conversion**: Converts LeRobot datasets organized in chunks
+- **Multi-video support**: Auto-detects and converts all video streams
+- **Terminal log support**: Parses raw `.log` files into `rcl_interfaces/msg/Log` messages with full metadata
+- **ROS2 format**: Outputs ROS2-compatible MCAP files
+
+## Architecture
+
+The converter uses an object-oriented architecture:
+
+- **DatasetInfo**: Parses `meta/info.json` to extract dataset structure (FPS, video streams, codecs, etc.)
+- **ConfigGenerator**: Automatically generates configuration from dataset metadata
+- **LeRobotConverter**: Orchestrates the conversion process
+- Uses **tabular2mcap** under the hood for MCAP writing
 
 ## Usage
 
+### Download Dataset
+
+If you wish to use an existing dataset offered by Hugging Face, use the following commands.
+
 ```bash
-# Download dataset
+# Download from Hugging Face
 uv run lerobot2mcap download lerobot/pusht -o ./data
 
-# Convert to MCAP
-uv run lerobot2mcap convert lerobot/pusht -o ./data
-
-# Specific episodes
+# Download specific episodes
 uv run lerobot2mcap download lerobot/pusht -o ./data -e 0 1 2
 ```
 
-Browse datasets: https://huggingface.co/lerobot
+### Convert to MCAP
+
+```bash
+# Convert all chunks (configuration generated automatically)
+uv run lerobot2mcap convert ~/.cache/huggingface/lerobot/{repo-id} -o ./mcap_output
+
+# Convert specific chunks
+uv run lerobot2mcap convert ~/.cache/huggingface/lerobot/{repo-id} -o ./mcap_output -c 0 1
+
+# Advanced: Custom converter functions (optional)
+uv run lerobot2mcap convert ~/.cache/huggingface/lerobot/{repo-id} -o ./mcap_output -f ./my_converter_functions.yaml
+```
+
+### Expected Dataset Structure
+
+Video file structure is an example only. Depending on hardware setup subfile names may change
+
+```
+dataset_root/
+├── meta/
+│   └── info.json           # Dataset metadata
+├── data/
+│   └── chunk-000/
+│       └── file-000.parquet
+├── videos/
+│   ├── observation.images.front/
+│   │   └── chunk-000/
+│   │       └── file-000.mp4
+│   └── observation.images.external/
+│       └── chunk-000/
+│           └── file-000.mp4
+└── recording.log           # Optional terminal log
+```
+
+## Output
+
+Each chunk produces one MCAP file with:
+- **Robot data** from parquet files (topic: `robot_data`)
+- **Video streams** for each camera (topics: `observation/images/front`, `observation/images/external`, etc.)
+- **Terminal logs** as `rcl_interfaces/msg/Log` if `.log` files present (topic: `terminal_log`)
+  - Includes full metadata: log level, timestamp, source file, line number, and message
+  - Supports multi-line log entries (e.g., stack traces)
+
+## How Configuration Works
+
+**You don't need to create any configuration files** - everything is automatic:
+
+1. **DatasetInfo** reads your `meta/info.json` to discover:
+   - Video streams and their codecs
+   - Dataset FPS and structure
+   - Data file patterns
+
+2. **ConfigGenerator** creates a config for each chunk:
+   - Tabular mappings for parquet files
+   - Video mappings for each camera stream
+   - Log mappings if `.log` files are present
+
+3. **tabular2mcap** uses this generated config to convert to MCAP
+
+### Advanced: Custom Converter Functions (Optional)
+
+By default, the converter uses [`configs/converter_functions.yaml`](configs/converter_functions.yaml) for data transformation. You can customize this with the `-f` flag:
+
+```yaml
+# Custom converter_functions.yaml
+functions:
+  row_to_message_with_timestamp:
+    schema_name: null
+    template: |
+      {
+        "timestamp": {
+          "sec": {{ (timestamp) | int }},
+          "nsec": {{ ((timestamp % 1) * 1_000_000_000) | int }}
+        }
+      }
+```
+
+**Note**: Log parsing is handled automatically by tabular2mcap's `LogConverter` - no converter function needed.
+
+## Development
+
+```bash
+# Install dependencies
+uv sync
+
+# Run tests
+uv run pytest
+
+# Build package
+uv build
+```
+
+## Browse Datasets
+
+https://huggingface.co/lerobot

--- a/README.md
+++ b/README.md
@@ -72,12 +72,6 @@ uv run lerobot2mcap convert ~/.cache/huggingface/lerobot/{repo-id} -o ./mcap_out
 # Convert specific episodes
 uv run lerobot2mcap convert ~/.cache/huggingface/lerobot/{repo-id} -o ./mcap_output -e 0 1 2
 
-# Convert specific chunks (for multi-chunk datasets)
-uv run lerobot2mcap convert ~/.cache/huggingface/lerobot/{repo-id} -o ./mcap_output -c 0 1
-
-# Combine: specific episodes from specific chunks
-uv run lerobot2mcap convert ~/.cache/huggingface/lerobot/{repo-id} -o ./mcap_output -c 0 -e 0 1 2
-
 # Advanced: Custom converter functions (optional)
 uv run lerobot2mcap convert ~/.cache/huggingface/lerobot/{repo-id} -o ./mcap_output -f ./my_converter_functions.yaml
 ```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Convert LeRobot datasets to MCAP format. The config file is automatically genera
 - **Multi-video support**: Auto-detects and converts all video streams
 - **Terminal log support**: Parses raw `.log` files into `rcl_interfaces/msg/Log` messages with full metadata
 - **ROS2 format**: Outputs ROS2-compatible MCAP files
+- **Cross-compatible**: Supports LeRobot v2.0, v2.1, and v3 dataset formats automatically
 
 ## Architecture
 
@@ -36,6 +37,32 @@ uv run lerobot2mcap download lerobot/pusht -o ./data
 uv run lerobot2mcap download lerobot/pusht -o ./data -e 0 1 2
 ```
 
+### Record Your Own Dataset With a .log File
+If you wish to record a regular dataset without the additional .log file, HuggingFace's tutorials have that covered. To record a dataset while capturing the terminal output, use the following command:
+
+```bash
+LOG_FILE=~/.cache/huggingface/lerobot/${HF_USER}/record-test.log
+lerobot-record \
+    --robot.type=so101_follower \
+    --robot.port=/dev/tty.usbmodem5A680114161 \
+    --robot.id=my_awesome_follower_arm \
+    --robot.cameras="{ 
+    front: {type: opencv, index_or_path: 0, width: 1920, height: 1080, fps: 30},
+    external: {type: opencv, index_or_path: 1, width: 640, height: 480, fps: 15}     
+    }" \
+    --teleop.type=so101_leader \
+    --teleop.port=/dev/tty.usbmodem5A680123701 \
+    --teleop.id=my_awesome_leader_arm \
+    --display_data=true \
+    --dataset.repo_id=${HF_USER}/record-test
+    --dataset.episode_time_s=60 \
+    --dataset.reset_time_s=0 \
+    --dataset.num_episodes=1 \
+    --dataset.single_task="recording edge cases" \
+    2>&1 | tee $LOG_FILE
+
+```
+
 ### Convert to MCAP
 
 ```bash
@@ -57,9 +84,39 @@ uv run lerobot2mcap convert ~/.cache/huggingface/lerobot/{repo-id} -o ./mcap_out
 
 ### Expected Dataset Structure
 
-Video file structure is an example only. Depending on hardware setup subfile names may change.
+The converter automatically detects and supports both LeRobot v2.0, v2.1, and v3 dataset formats. Example input file structures are given below for v3 and v2.1 (very similar to v2). 
 
-Each episode is represented as a separate file (file-000, file-001, file-002, etc.) within a chunk.
+#### LeRobot v3 Format
+
+Multiple episodes will be concatenated into the same files, based on episode and MP4 file size limits defined in the lerobot codebase. The following file structure is an example only; the method and conditions, and recording parameters that data is collected with will dicate how many episodes are merged per file.  
+```
+dataset_root/
+├── meta/
+│   ├── info.json           # Dataset metadata (includes total_episodes)
+│   ├── episodes.jsonl
+│   └── tasks.jsonl
+├── data/
+│   └── chunk-000/
+│       ├── file-000.parquet  # Episode 0-3
+│       ├── file-001.parquet  # Episode 4-5
+│       └── file-002.parquet  # Episode 6-9
+├── videos/
+│   ├── observation.images.front/
+│   │   └── chunk-000/
+│   │       ├── file-000.mp4  # Episode 0-3
+│   │       ├── file-001.mp4  # Episode 4-5
+│   │       └── file-002.mp4  # Episode 6-9
+│   └── observation.images.external/
+│       └── chunk-000/
+│           ├── file-000.mp4  # Episode 0-3
+│           ├── file-001.mp4  # Episode 4-5
+│           └── file-002.mp4  # Episode 6-9
+└── recording.log           # Optional terminal log
+```
+
+#### LeRobot v2.1 Format
+
+Episodes use 6-digit indices (episode_000000, episode_000001, etc.).
 
 ```
 dataset_root/
@@ -69,22 +126,22 @@ dataset_root/
 │   └── tasks.jsonl
 ├── data/
 │   └── chunk-000/
-│       ├── file-000.parquet  # Episode 0
-│       ├── file-001.parquet  # Episode 1
-│       └── file-002.parquet  # Episode 2
-├── videos/
-│   ├── observation.images.front/
-│   │   └── chunk-000/
-│   │       ├── file-000.mp4  # Episode 0
-│   │       ├── file-001.mp4  # Episode 1
-│   │       └── file-002.mp4  # Episode 2
-│   └── observation.images.external/
-│       └── chunk-000/
-│           ├── file-000.mp4  # Episode 0
-│           ├── file-001.mp4  # Episode 1
-│           └── file-002.mp4  # Episode 2
-└── recording.log           # Optional terminal log
+│       ├── episode_000000.parquet  # Episode 0
+│       ├── episode_000001.parquet  # Episode 1
+│       └── episode_000002.parquet  # Episode 2
+└── videos/
+    └── chunk-000/
+        ├── observation.images.phone/
+        │   ├── episode_000000.mp4  # Episode 0
+        │   ├── episode_000001.mp4  # Episode 1
+        │   └── episode_000002.mp4  # Episode 2
+        └── observation.images.external/
+            ├── episode_000000.mp4  # Episode 0
+            ├── episode_000001.mp4  # Episode 1
+            └── episode_000002.mp4  # Episode 2
 ```
+
+**Note**: The converter automatically detects which format your dataset uses from `meta/info.json` and handles it appropriately.
 
 ## Output
 

--- a/lerobot2mcap/__init__.py
+++ b/lerobot2mcap/__init__.py
@@ -23,15 +23,15 @@ PACKAGE_ROOT = Path(__file__).parent.parent
 DEFAULT_CONVERTER_FUNCTIONS = str(PACKAGE_ROOT / "configs" / "converter_functions.yaml")
 
 
-def download_dataset(dataset_id: str, output_dir: str, episodes: list[int] | None = None) -> bool:
-    """Download a lerobot dataset from Hugging Face Hub."""    
+def download_dataset(dataset_id: str, output_dir: Path, episodes: list[int] | None = None) -> bool:
+    """Download a lerobot dataset from Hugging Face Hub."""
     print(f"📥 Downloading: {dataset_id}")
     if episodes:
         print(f"   Episodes: {episodes}")
     print(f"   Output: {output_dir}")
-    
+
     try:
-        dataset = LeRobotDataset(dataset_id, root=output_dir, episodes=episodes)
+        dataset = LeRobotDataset(dataset_id, root=str(output_dir), episodes=episodes)
         print(f"✓ Episodes: {dataset.num_episodes}, Frames: {dataset.num_frames}, FPS: {dataset.fps}")
         return True
     except Exception as e:
@@ -46,13 +46,11 @@ def convert_dataset(
 ) -> bool:
     """
     Convert a LeRobot dataset to MCAP format (chunk-based).
-
     Args:
         dataset_root: Root directory of the LeRobot dataset
         output_dir: Output directory for MCAP files
         converter_functions_path: Path to converter_functions.yaml
         chunks: List of chunk indices to convert (None = all chunks)
-
     Returns:
         True if conversion succeeded, False otherwise
     """
@@ -75,8 +73,7 @@ def convert_dataset(
         # Perform conversion
         success = converter.convert(
             output_dir=output_dir,
-            chunks=chunks,
-            keep_temp_files=True
+            chunks=chunks
         )
 
         return success
@@ -105,22 +102,19 @@ def main():
     convert_parser.add_argument("-f", "--converter-functions", default=DEFAULT_CONVERTER_FUNCTIONS, help=f"Path to converter_functions.yaml file (default: {DEFAULT_CONVERTER_FUNCTIONS})")
 
     args = parser.parse_args()
+
     if args.command == "download":
-        if args.output_dir is None:
-            args.output_dir = Path("./data") / args.dataset_id
-        else:
-            args.output_dir = Path(args.output_dir)
-        return 0 if download_dataset(args.dataset_id, args.output_dir, args.episodes) else 1
-    elif args.command == "convert":
-        if args.output_dir is None:
-            args.output_dir = Path(args.input_dir) / "mcap"
-        else:
-            args.output_dir = Path(args.output_dir)
+        output_dir = Path(args.output_dir) if args.output_dir else Path("./data") / args.dataset_id
+        return 0 if download_dataset(args.dataset_id, output_dir, args.episodes) else 1
+
+    if args.command == "convert":
+        output_dir = Path(args.output_dir) if args.output_dir else Path(args.input_dir) / "mcap"
         return 0 if convert_dataset(
             Path(args.input_dir),
-            args.output_dir,
+            output_dir,
             Path(args.converter_functions),
             args.chunks
         ) else 1
+
     parser.print_help()
     return 0

--- a/lerobot2mcap/__init__.py
+++ b/lerobot2mcap/__init__.py
@@ -17,6 +17,7 @@ logging.basicConfig(
     format="%(levelname)s %(asctime)s %(filename)s:%(lineno)d %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
 )
+logger = logging.getLogger(__name__)
 
 # Get the package root directory
 PACKAGE_ROOT = Path(__file__).parent.parent
@@ -27,19 +28,19 @@ def download_dataset(
     dataset_id: str, output_dir: Path, episodes: list[int] | None = None
 ) -> bool:
     """Download a lerobot dataset from Hugging Face Hub."""
-    print(f" Downloading: {dataset_id}")
+    logger.info(f"Downloading: {dataset_id}")
     if episodes:
-        print(f"   Episodes: {episodes}")
-    print(f"   Output: {output_dir}")
+        logger.info(f"  Episodes: {episodes}")
+    logger.info(f"  Output: {output_dir}")
 
     try:
         dataset = LeRobotDataset(dataset_id, root=str(output_dir), episodes=episodes)
-        print(
-            f"✓ Episodes: {dataset.num_episodes}, Frames: {dataset.num_frames}, FPS: {dataset.fps}"
+        logger.info(
+            f"Download complete - Episodes: {dataset.num_episodes}, Frames: {dataset.num_frames}, FPS: {dataset.fps}"
         )
         return True
     except Exception as e:
-        print(f"❌ Error: {e}")
+        logger.error(f"Download failed: {e}")
         return False
 
 
@@ -59,18 +60,15 @@ def convert_dataset(
         dataset_root: Root directory of the LeRobot dataset
         output_dir: Output directory for MCAP files
         converter_functions_path: Path to converter_functions.yaml
-        chunks: List of chunk indices to convert (None = all chunks)
         episodes: List of episode indices to convert (None = all episodes)
     Returns:
         True if conversion succeeded, False otherwise
     """
-    print(f"🔄 Converting: {dataset_root}")
-    if chunks:
-        print(f"   Chunks: {chunks}")
+    logger.info(f"Converting dataset: {dataset_root}")
     if episodes:
-        print(f"   Episodes: {episodes}")
-    print(f"   Output: {output_dir}")
-    print(f"   Converter functions: {converter_functions_path}")
+        logger.info(f"  Episodes: {episodes}")
+    logger.info(f"  Output: {output_dir}")
+    logger.info(f"  Converter functions: {converter_functions_path}")
 
     try:
         # Initialize the converter
@@ -79,7 +77,7 @@ def convert_dataset(
         )
 
         # Show conversion plan
-        print("\n" + converter.get_conversion_plan(chunks))
+        logger.info("\n" + converter.get_conversion_plan(chunks))
 
         # Perform conversion
         success = converter.convert(
@@ -89,10 +87,7 @@ def convert_dataset(
         return success
 
     except Exception as e:
-        print(f"❌ Error: {e}")
-        import traceback
-
-        traceback.print_exc()
+        logger.exception(f"Conversion failed: {e}")
         return False
 
 
@@ -139,13 +134,6 @@ def main():
         help="Output directory for MCAP files (default: input_dir/mcap)",
     )
     convert_parser.add_argument(
-        "-c",
-        "--chunks",
-        type=int,
-        nargs="+",
-        help="Chunk IDs to convert (e.g., 0 1 2). If not specified, all chunks will be converted.",
-    )
-    convert_parser.add_argument(
         "-e",
         "--episodes",
         type=int,
@@ -185,7 +173,7 @@ def main():
             else dataset_root / "mcap_conversion"
         )
         converter_functions = Path(args.converter_functions)
-        chunks = args.chunks
+        chunks = None  # Convert all chunks
         episodes = args.episodes
 
     else:

--- a/lerobot2mcap/__init__.py
+++ b/lerobot2mcap/__init__.py
@@ -1,19 +1,25 @@
 """LeRobot to MCAP converter."""
 
 import argparse
+import logging
 from importlib.metadata import version
-from lerobot.datasets.lerobot_dataset import LeRobotDataset
-from tabular2mcap import McapConverter
-from tabular2mcap.loader import McapConversionConfig
 from pathlib import Path
-import yaml
-from jinja2 import Template
-from tqdm import tqdm
+
+from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+from .converter import LeRobotConverter
+
 __version__ = version("lerobot2mcap")
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(levelname)s %(asctime)s %(filename)s:%(lineno)d %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
 
 # Get the package root directory
 PACKAGE_ROOT = Path(__file__).parent.parent
-DEFAULT_CONFIG = str(PACKAGE_ROOT / "configs" / "config.yaml")
 DEFAULT_CONVERTER_FUNCTIONS = str(PACKAGE_ROOT / "configs" / "converter_functions.yaml")
 
 
@@ -32,38 +38,54 @@ def download_dataset(dataset_id: str, output_dir: str, episodes: list[int] | Non
         print(f"❌ Error: {e}")
         return False
 
-def modified_load_mcap_conversion_config(config_path: Path, episode_id: str) -> McapConversionConfig:
-    """Load and validate mapping configuration from YAML file"""
-    with open(config_path) as f:
-        template = Template(f.read())
-        config = yaml.safe_load(template.render(episode_id=episode_id))
-    return McapConversionConfig.model_validate(config)
+def convert_dataset(
+    dataset_root: Path,
+    output_dir: Path,
+    converter_functions_path: Path,
+    chunks: list[int] | None = None,
+) -> bool:
+    """
+    Convert a LeRobot dataset to MCAP format (chunk-based).
 
-def convert_dataset(input_dir: Path, output_dir: Path,
-                    config_path: Path, 
-                    converter_functions_path: Path,
-                    episodes: list[int] | None = None) -> bool:
-    """Convert a lerobot dataset to MCAP format."""
-    print(f"🔄 Converting: {input_dir}")
-    if episodes:
-        print(f"   Episodes: {episodes}")
+    Args:
+        dataset_root: Root directory of the LeRobot dataset
+        output_dir: Output directory for MCAP files
+        converter_functions_path: Path to converter_functions.yaml
+        chunks: List of chunk indices to convert (None = all chunks)
+
+    Returns:
+        True if conversion succeeded, False otherwise
+    """
+    print(f"🔄 Converting: {dataset_root}")
+    if chunks:
+        print(f"   Chunks: {chunks}")
     print(f"   Output: {output_dir}")
-    print(f"   Config: {config_path}")
     print(f"   Converter functions: {converter_functions_path}")
-    
-    if not output_dir.exists():
-        output_dir.mkdir(parents=True, exist_ok=True)
-    if episodes is None:
-        episode_ids = [p.stem for p in input_dir.glob("**/episode_*.parquet")]
-    else:
-        episode_ids = [f"episode_{episode_id:06d}" for episode_id in episodes]
-    for episode_id in tqdm(episode_ids, desc="Converting episodes"):
-        mcap_converter = McapConverter(config_path, converter_functions_path)
-        # mcap_config is loaded twice, once in the constructor which is overwritten by the modified_load_mcap_conversion_config function
-        mcap_converter.mcap_config = modified_load_mcap_conversion_config(config_path, episode_id)
-        mcap_converter.convert(input_dir, output_dir / f"{episode_id}.mcap")
 
-    return True
+    try:
+        # Initialize the converter with new OOP architecture
+        converter = LeRobotConverter(
+            dataset_root=dataset_root,
+            converter_functions_path=converter_functions_path
+        )
+
+        # Show conversion plan
+        print("\n" + converter.get_conversion_plan(chunks))
+
+        # Perform conversion
+        success = converter.convert(
+            output_dir=output_dir,
+            chunks=chunks,
+            keep_temp_files=True
+        )
+
+        return success
+
+    except Exception as e:
+        print(f"❌ Error: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
 
 
 def main():
@@ -77,12 +99,11 @@ def main():
     download_parser.add_argument("-e", "--episodes", type=int, nargs="+", help="Episode IDs to download (e.g., 0 1 2). If not specified, all episodes will be downloaded.")
     
     convert_parser = subparsers.add_parser("convert", help="Convert a LeRobot dataset to MCAP format")
-    convert_parser.add_argument("input_dir", help="Input directory containing LeRobot dataset")
-    convert_parser.add_argument("-o", "--output-dir", default=None, help="Output directory for MCAP files")
-    convert_parser.add_argument("-e", "--episodes", type=int, nargs="+", help="Episode IDs to convert (e.g., 0 1 2). If not specified, all episodes will be converted.")
-    convert_parser.add_argument("-c", "--config", default=DEFAULT_CONFIG, help=f"Path to config.yaml file (default: {DEFAULT_CONFIG})")
+    convert_parser.add_argument("input_dir", help="Input directory containing LeRobot dataset (dataset root with meta/info.json)")
+    convert_parser.add_argument("-o", "--output-dir", default=None, help="Output directory for MCAP files (default: input_dir/mcap)")
+    convert_parser.add_argument("-c", "--chunks", type=int, nargs="+", help="Chunk IDs to convert (e.g., 0 1 2). If not specified, all chunks will be converted.")
     convert_parser.add_argument("-f", "--converter-functions", default=DEFAULT_CONVERTER_FUNCTIONS, help=f"Path to converter_functions.yaml file (default: {DEFAULT_CONVERTER_FUNCTIONS})")
-    
+
     args = parser.parse_args()
     if args.command == "download":
         if args.output_dir is None:
@@ -95,6 +116,11 @@ def main():
             args.output_dir = Path(args.input_dir) / "mcap"
         else:
             args.output_dir = Path(args.output_dir)
-        return 0 if convert_dataset(Path(args.input_dir), args.output_dir, Path(args.config), Path(args.converter_functions), args.episodes) else 1
+        return 0 if convert_dataset(
+            Path(args.input_dir),
+            args.output_dir,
+            Path(args.converter_functions),
+            args.chunks
+        ) else 1
     parser.print_help()
     return 0

--- a/lerobot2mcap/__init__.py
+++ b/lerobot2mcap/__init__.py
@@ -46,7 +46,10 @@ def convert_dataset(
     episodes: list[int] | None = None,
 ) -> bool:
     """
-    Convert a LeRobot dataset to MCAP format (episode-based).
+    Convert a LeRobot dataset to MCAP format.
+    Iterates through each chunk and converts all episodes within that chunk.
+    Each episode produces a separate MCAP file in its own directory.
+
     Args:
         dataset_root: Root directory of the LeRobot dataset
         output_dir: Output directory for MCAP files

--- a/lerobot2mcap/__init__.py
+++ b/lerobot2mcap/__init__.py
@@ -151,7 +151,7 @@ def main():
 
     # Handle download command
     if args.command == "download":
-        download_dir = Path(args.output_dir) if args.output_dir else Path("./data")
+        download_dir = Path(args.output_dir).expanduser() if args.output_dir else Path("./data")
 
         # Download the dataset
         if not download_dataset(args.dataset_id, download_dir, args.episodes):
@@ -166,13 +166,13 @@ def main():
 
     elif args.command == "convert":
         # Set parameters from convert command arguments
-        dataset_root = Path(args.input_dir)
+        dataset_root = Path(args.input_dir).expanduser()
         mcap_output_dir = (
-            Path(args.output_dir)
+            Path(args.output_dir).expanduser()
             if args.output_dir
             else dataset_root / "mcap_conversion"
         )
-        converter_functions = Path(args.converter_functions)
+        converter_functions = Path(args.converter_functions).expanduser()
         chunks = None  # Convert all chunks
         episodes = args.episodes
 

--- a/lerobot2mcap/__init__.py
+++ b/lerobot2mcap/__init__.py
@@ -163,9 +163,7 @@ def main():
 
     # Handle download command
     if args.command == "download":
-        download_dir = (
-            Path(args.output_dir) if args.output_dir else Path("./data")
-        )
+        download_dir = Path(args.output_dir) if args.output_dir else Path("./data")
 
         # Download the dataset
         if not download_dataset(args.dataset_id, download_dir, args.episodes):
@@ -182,7 +180,9 @@ def main():
         # Set parameters from convert command arguments
         dataset_root = Path(args.input_dir)
         mcap_output_dir = (
-            Path(args.output_dir) if args.output_dir else dataset_root / "mcap_conversion"
+            Path(args.output_dir)
+            if args.output_dir
+            else dataset_root / "mcap_conversion"
         )
         converter_functions = Path(args.converter_functions)
         chunks = args.chunks

--- a/lerobot2mcap/__init__.py
+++ b/lerobot2mcap/__init__.py
@@ -14,8 +14,8 @@ __version__ = version("lerobot2mcap")
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
-    format='%(levelname)s %(asctime)s %(filename)s:%(lineno)d %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S'
+    format="%(levelname)s %(asctime)s %(filename)s:%(lineno)d %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
 )
 
 # Get the package root directory
@@ -23,20 +23,25 @@ PACKAGE_ROOT = Path(__file__).parent.parent
 DEFAULT_CONVERTER_FUNCTIONS = str(PACKAGE_ROOT / "configs" / "converter_functions.yaml")
 
 
-def download_dataset(dataset_id: str, output_dir: Path, episodes: list[int] | None = None) -> bool:
+def download_dataset(
+    dataset_id: str, output_dir: Path, episodes: list[int] | None = None
+) -> bool:
     """Download a lerobot dataset from Hugging Face Hub."""
-    print(f"📥 Downloading: {dataset_id}")
+    print(f" Downloading: {dataset_id}")
     if episodes:
         print(f"   Episodes: {episodes}")
     print(f"   Output: {output_dir}")
 
     try:
         dataset = LeRobotDataset(dataset_id, root=str(output_dir), episodes=episodes)
-        print(f"✓ Episodes: {dataset.num_episodes}, Frames: {dataset.num_frames}, FPS: {dataset.fps}")
+        print(
+            f"✓ Episodes: {dataset.num_episodes}, Frames: {dataset.num_frames}, FPS: {dataset.fps}"
+        )
         return True
     except Exception as e:
         print(f"❌ Error: {e}")
         return False
+
 
 def convert_dataset(
     dataset_root: Path,
@@ -68,10 +73,9 @@ def convert_dataset(
     print(f"   Converter functions: {converter_functions_path}")
 
     try:
-        # Initialize the converter with new OOP architecture
+        # Initialize the converter
         converter = LeRobotConverter(
-            dataset_root=dataset_root,
-            converter_functions_path=converter_functions_path
+            dataset_root=dataset_root, converter_functions_path=converter_functions_path
         )
 
         # Show conversion plan
@@ -79,9 +83,7 @@ def convert_dataset(
 
         # Perform conversion
         success = converter.convert(
-            output_dir=output_dir,
-            chunks=chunks,
-            episodes=episodes
+            output_dir=output_dir, chunks=chunks, episodes=episodes
         )
 
         return success
@@ -89,42 +91,112 @@ def convert_dataset(
     except Exception as e:
         print(f"❌ Error: {e}")
         import traceback
+
         traceback.print_exc()
         return False
 
 
 def main():
-    parser = argparse.ArgumentParser(prog="lerobot2mcap", description="Convert LeRobot datasets to MCAP format")
-    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    parser = argparse.ArgumentParser(
+        prog="lerobot2mcap", description="Convert LeRobot datasets to MCAP format"
+    )
+    parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {__version__}"
+    )
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
-    
-    download_parser = subparsers.add_parser("download", help="Download a LeRobot dataset")
+
+    # Define download parser arguments
+    download_parser = subparsers.add_parser(
+        "download", help="Download a LeRobot dataset"
+    )
     download_parser.add_argument("dataset_id", help="Dataset ID (e.g., lerobot/pusht)")
-    download_parser.add_argument("-o", "--output-dir", default=None, help="Output directory (default: dataset_id)")
-    download_parser.add_argument("-e", "--episodes", type=int, nargs="+", help="Episode IDs to download (e.g., 0 1 2). If not specified, all episodes will be downloaded.")
-    
-    convert_parser = subparsers.add_parser("convert", help="Convert a LeRobot dataset to MCAP format")
-    convert_parser.add_argument("input_dir", help="Input directory containing LeRobot dataset (dataset root with meta/info.json)")
-    convert_parser.add_argument("-o", "--output-dir", default=None, help="Output directory for MCAP files (default: input_dir/mcap)")
-    convert_parser.add_argument("-c", "--chunks", type=int, nargs="+", help="Chunk IDs to convert (e.g., 0 1 2). If not specified, all chunks will be converted.")
-    convert_parser.add_argument("-e", "--episodes", type=int, nargs="+", help="Episode IDs to convert (e.g., 0 1 2). If not specified, all episodes will be converted.")
-    convert_parser.add_argument("-f", "--converter-functions", default=DEFAULT_CONVERTER_FUNCTIONS, help=f"Path to converter_functions.yaml file (default: {DEFAULT_CONVERTER_FUNCTIONS})")
+    download_parser.add_argument(
+        "-o",
+        "--output-dir",
+        default=None,
+        help="Output directory (default: dataset_id)",
+    )
+    download_parser.add_argument(
+        "-e",
+        "--episodes",
+        type=int,
+        nargs="+",
+        help="Episode IDs to download (e.g., 0 1 2). If not specified, all episodes will be downloaded.",
+    )
+
+    # Define
+    convert_parser = subparsers.add_parser(
+        "convert", help="Convert a LeRobot dataset to MCAP format"
+    )
+    convert_parser.add_argument(
+        "input_dir",
+        help="Input directory containing LeRobot dataset (dataset root with meta/info.json)",
+    )
+    convert_parser.add_argument(
+        "-o",
+        "--output-dir",
+        default=None,
+        help="Output directory for MCAP files (default: input_dir/mcap)",
+    )
+    convert_parser.add_argument(
+        "-c",
+        "--chunks",
+        type=int,
+        nargs="+",
+        help="Chunk IDs to convert (e.g., 0 1 2). If not specified, all chunks will be converted.",
+    )
+    convert_parser.add_argument(
+        "-e",
+        "--episodes",
+        type=int,
+        nargs="+",
+        help="Episode IDs to convert (e.g., 0 1 2). If not specified, all episodes will be converted.",
+    )
+    convert_parser.add_argument(
+        "-f",
+        "--converter-functions",
+        default=DEFAULT_CONVERTER_FUNCTIONS,
+        help=f"Path to converter_functions.yaml file (default: {DEFAULT_CONVERTER_FUNCTIONS})",
+    )
 
     args = parser.parse_args()
 
+    # Handle download command
     if args.command == "download":
-        output_dir = Path(args.output_dir) if args.output_dir else Path("./data") / args.dataset_id
-        return 0 if download_dataset(args.dataset_id, output_dir, args.episodes) else 1
+        download_dir = (
+            Path(args.output_dir) if args.output_dir else Path("./data")
+        )
 
-    if args.command == "convert":
-        output_dir = Path(args.output_dir) if args.output_dir else Path(args.input_dir) / "mcap"
-        return 0 if convert_dataset(
-            Path(args.input_dir),
-            output_dir,
-            Path(args.converter_functions),
-            args.chunks,
-            args.episodes
-        ) else 1
+        # Download the dataset
+        if not download_dataset(args.dataset_id, download_dir, args.episodes):
+            return 1  # Download failed
 
-    parser.print_help()
-    return 0
+        # Set dataset root for conversion
+        dataset_root = download_dir
+        mcap_output_dir = dataset_root / "mcap_conversion"
+        converter_functions = Path(DEFAULT_CONVERTER_FUNCTIONS)
+        chunks = None  # Convert all chunks
+        episodes = args.episodes  # Use same episode filter as download
+
+    elif args.command == "convert":
+        # Set parameters from convert command arguments
+        dataset_root = Path(args.input_dir)
+        mcap_output_dir = (
+            Path(args.output_dir) if args.output_dir else dataset_root / "mcap_conversion"
+        )
+        converter_functions = Path(args.converter_functions)
+        chunks = args.chunks
+        episodes = args.episodes
+
+    else:
+        # No command provided
+        parser.print_help()
+        return 0
+
+    # Perform conversion (always happens after download, or standalone)
+    if convert_dataset(
+        dataset_root, mcap_output_dir, converter_functions, chunks, episodes
+    ):
+        return 0
+    else:
+        return 1

--- a/lerobot2mcap/__init__.py
+++ b/lerobot2mcap/__init__.py
@@ -43,20 +43,24 @@ def convert_dataset(
     output_dir: Path,
     converter_functions_path: Path,
     chunks: list[int] | None = None,
+    episodes: list[int] | None = None,
 ) -> bool:
     """
-    Convert a LeRobot dataset to MCAP format (chunk-based).
+    Convert a LeRobot dataset to MCAP format (episode-based).
     Args:
         dataset_root: Root directory of the LeRobot dataset
         output_dir: Output directory for MCAP files
         converter_functions_path: Path to converter_functions.yaml
         chunks: List of chunk indices to convert (None = all chunks)
+        episodes: List of episode indices to convert (None = all episodes)
     Returns:
         True if conversion succeeded, False otherwise
     """
     print(f"🔄 Converting: {dataset_root}")
     if chunks:
         print(f"   Chunks: {chunks}")
+    if episodes:
+        print(f"   Episodes: {episodes}")
     print(f"   Output: {output_dir}")
     print(f"   Converter functions: {converter_functions_path}")
 
@@ -73,7 +77,8 @@ def convert_dataset(
         # Perform conversion
         success = converter.convert(
             output_dir=output_dir,
-            chunks=chunks
+            chunks=chunks,
+            episodes=episodes
         )
 
         return success
@@ -99,6 +104,7 @@ def main():
     convert_parser.add_argument("input_dir", help="Input directory containing LeRobot dataset (dataset root with meta/info.json)")
     convert_parser.add_argument("-o", "--output-dir", default=None, help="Output directory for MCAP files (default: input_dir/mcap)")
     convert_parser.add_argument("-c", "--chunks", type=int, nargs="+", help="Chunk IDs to convert (e.g., 0 1 2). If not specified, all chunks will be converted.")
+    convert_parser.add_argument("-e", "--episodes", type=int, nargs="+", help="Episode IDs to convert (e.g., 0 1 2). If not specified, all episodes will be converted.")
     convert_parser.add_argument("-f", "--converter-functions", default=DEFAULT_CONVERTER_FUNCTIONS, help=f"Path to converter_functions.yaml file (default: {DEFAULT_CONVERTER_FUNCTIONS})")
 
     args = parser.parse_args()
@@ -113,7 +119,8 @@ def main():
             Path(args.input_dir),
             output_dir,
             Path(args.converter_functions),
-            args.chunks
+            args.chunks,
+            args.episodes
         ) else 1
 
     parser.print_help()

--- a/lerobot2mcap/config_generator.py
+++ b/lerobot2mcap/config_generator.py
@@ -112,7 +112,7 @@ class ConfigGenerator:
         return config
 
     def generate_episode_config(
-        self, episode_index: int, chunk_index: int, include_log: bool = False
+        self, episode_index: int, chunk_index: int, include_log: bool = True
     ) -> dict:
         """
         Generate configuration dictionary for a specific episode.
@@ -120,7 +120,8 @@ class ConfigGenerator:
         Args:
             episode_index: The episode index (used as file_index in paths)
             chunk_index: The chunk index
-            include_log: Whether to include log file as MCAP attachment
+            include_log: Whether to include log file as MCAP attachment (default: True,
+                tabular2mcap will auto-detect if the file exists)
 
         Returns:
             Configuration dictionary compatible with McapConversionConfig

--- a/lerobot2mcap/config_generator.py
+++ b/lerobot2mcap/config_generator.py
@@ -1,0 +1,196 @@
+"""Configuration generator for tabular2mcap conversion."""
+
+import logging
+from pathlib import Path
+
+from .dataset_info import DatasetInfo
+
+logger = logging.getLogger(__name__)
+
+
+class ConfigGenerator:
+    """Generates tabular2mcap configuration dynamically based on dataset info."""
+
+    def __init__(self, dataset_info: DatasetInfo):
+        """
+        Initialize ConfigGenerator with dataset information.
+
+        Args:
+            dataset_info: DatasetInfo instance containing dataset metadata
+        """
+        self.dataset_info = dataset_info
+        logger.info(f"Initialized ConfigGenerator for dataset with {len(dataset_info.video_keys)} video streams")
+
+    def generate_chunk_config(self, chunk_index: int, include_log: bool = False) -> dict:
+        """
+        Generate configuration dictionary for a specific chunk.
+
+        Args:
+            chunk_index: The chunk index to generate config for
+            include_log: Whether to include log file mapping
+
+        Returns:
+            Configuration dictionary compatible with McapConversionConfig
+        """
+        # Combine video and log mappings in other_mappings
+        other_mappings = self._generate_video_mappings(chunk_index)
+        if include_log:
+            other_mappings.extend(self._generate_log_mappings())
+
+        config = {
+            "writer_format": "ros2",
+            "tabular_mappings": self._generate_tabular_mappings(chunk_index),
+            "other_mappings": other_mappings,
+            "attachments": [],
+            "metadata": [],
+        }
+
+        logger.debug(f"Generated config for chunk {chunk_index}: "
+                    f"{len(config['tabular_mappings'])} tabular, "
+                    f"{len(config['other_mappings'])} other mappings")
+
+        return config
+
+    def _generate_tabular_mappings(self, chunk_index: int) -> list[dict]:
+        """
+        Generate tabular mapping configurations.
+
+        Creates mappings for parquet data files.
+
+        Args:
+            chunk_index: The chunk index
+
+        Returns:
+            List of tabular mapping configurations
+        """
+        mappings = []
+
+        # Parquet file mapping
+        data_path_template = self.dataset_info.data.get(
+            "data_path",
+            "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet"
+        )
+        # Format chunk_index but keep file_index as wildcard
+        # Replace {chunk_index:03d} with actual value, and {file_index:03d} with *
+        parquet_pattern = data_path_template.replace(
+            "{chunk_index:03d}", f"{chunk_index:03d}"
+        ).replace(
+            "{file_index:03d}", "*"
+        )
+
+        mappings.append({
+            "file_pattern": f"**/{parquet_pattern}",
+            "converter_functions": [
+                {
+                    "function_name": "row_to_message_with_timestamp",
+                    "schema_name": None,  # Will auto-generate schema
+                    "topic_suffix": "robot_data",
+                    "exclude_columns": ["timestamp"],
+                }
+            ],
+        })
+
+        return mappings
+
+    def _generate_video_mappings(self, chunk_index: int) -> list[dict]:
+        """
+        Generate video mapping configurations for all video streams.
+
+        Args:
+            chunk_index: The chunk index
+
+        Returns:
+            List of CompressedVideoMappingConfig dictionaries
+        """
+        mappings = []
+        video_path_template = self.dataset_info.data.get(
+            "video_path",
+            "videos/{video_key}/chunk-{chunk_index:03d}/file-{file_index:03d}.mp4"
+        )
+
+        for video_key in self.dataset_info.video_keys:
+            # Get codec for this video stream
+            codec = self.dataset_info.get_video_codec(video_key)
+
+            # Map LeRobot codec names to tabular2mcap format names
+            codec_map = {
+                "av1": "av1",
+                "h264": "h264",
+                "h265": "h265",
+                "vp9": "vp9",
+            }
+            video_format = codec_map.get(codec, "h264")
+
+            # Generate file pattern for this video stream
+            # Replace placeholders: {video_key}, {chunk_index:03d}, {file_index:03d}
+            video_pattern = (
+                video_path_template
+                .replace("{video_key}", video_key)
+                .replace("{chunk_index:03d}", f"{chunk_index:03d}")
+                .replace("{file_index:03d}", "*")
+            )
+
+            # Generate topic suffix from video_key
+            # "observation.images.front" -> "observation/images/front"
+            topic_suffix = video_key.replace(".", "/")
+
+            # Get frame_id
+            frame_id = self.dataset_info.get_video_frame_id(video_key)
+
+            mappings.append({
+                "type": "compressed_video",
+                "file_pattern": f"**/{video_pattern}",
+                "topic_suffix": topic_suffix,
+                "frame_id": frame_id,
+                "format": video_format,
+            })
+
+        return mappings
+
+    def _generate_log_mappings(self) -> list[dict]:
+        """
+        Generate log mapping configurations for terminal output logs.
+
+        Uses tabular2mcap's built-in LogConverter to parse raw .log files
+        directly into rcl_interfaces/msg/Log messages.
+
+        Returns:
+            List of LogMappingConfig dictionaries
+        """
+        return [{
+            "type": "log",
+            "file_pattern": "**/*.log",
+            "topic_suffix": "terminal_log",
+            "format_template": r"^(?P<levelname>INFO|DEBUG|WARNING|ERROR|FATAL)\s(?P<asctime>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2})\s(?P<filename>\S+):(?P<lineno>\d+)\s(?P<message>.*)$",
+            "datetime_format": "%Y-%m-%d %H:%M:%S",
+        }]
+
+    def generate_config_summary(self, chunk_index: int) -> str:
+        """
+        Generate a human-readable summary of the configuration.
+
+        Args:
+            chunk_index: The chunk index
+
+        Returns:
+            Formatted string describing the configuration
+        """
+        config = self.generate_chunk_config(chunk_index, include_log=True)
+
+        summary = [
+            f"Configuration for chunk-{chunk_index:03d}:",
+            f"  Writer format: {config['writer_format']}",
+            f"  Tabular mappings: {len(config['tabular_mappings'])}",
+        ]
+
+        for i, mapping in enumerate(config['tabular_mappings'], 1):
+            summary.append(f"    {i}. {mapping['file_pattern']}")
+
+        summary.append(f"  Video mappings: {len(config['other_mappings'])}")
+        for i, mapping in enumerate(config['other_mappings'], 1):
+            summary.append(
+                f"    {i}. {mapping['topic_suffix']} "
+                f"({mapping['format']}, frame_id={mapping['frame_id']})"
+            )
+
+        return "\n".join(summary)

--- a/lerobot2mcap/config_generator.py
+++ b/lerobot2mcap/config_generator.py
@@ -14,29 +14,44 @@ class ConfigGenerator:
     def __init__(self, dataset_info: DatasetInfo):
         """
         Initialize ConfigGenerator with dataset information.
-
         Args:
             dataset_info: DatasetInfo instance containing dataset metadata
         """
         self.dataset_info = dataset_info
         logger.info(f"Initialized ConfigGenerator for dataset with {len(dataset_info.video_keys)} video streams")
 
+    @staticmethod
+    def _format_file_pattern(template: str, chunk_index: int, **kwargs) -> str:
+        """
+        Format a file path template for a specific chunk, converting file_index to wildcard.
+        Args:
+            template: Path template with placeholders (e.g., "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet")
+            chunk_index: The chunk index to substitute
+            **kwargs: Additional key-value pairs to substitute in the template
+        Returns:
+            Formatted pattern with chunk_index filled and file_index as wildcard
+        """
+        # First format the chunk_index and any other kwargs
+        formatted = template.format(chunk_index=chunk_index, file_index=0, **kwargs)
+        # Then replace the formatted file_index (000) with wildcard
+        # This assumes file_index uses :03d format
+        formatted = formatted.replace("file-000", "file-*")
+        return formatted
+
     def generate_chunk_config(self, chunk_index: int, include_log: bool = False) -> dict:
         """
         Generate configuration dictionary for a specific chunk.
-
         Args:
             chunk_index: The chunk index to generate config for
             include_log: Whether to include log file mapping
-
         Returns:
             Configuration dictionary compatible with McapConversionConfig
         """
-        # Combine video and log mappings in other_mappings
+        # Video mappings go in other_mappings
         other_mappings = self._generate_video_mappings(chunk_index)
-        if include_log:
-            other_mappings.extend(self._generate_log_mappings())
 
+        # Log mappings go in a separate field (if tabular2mcap supports it)
+        # For now, we'll exclude logs to avoid validation errors
         config = {
             "writer_format": "ros2",
             "tabular_mappings": self._generate_tabular_mappings(chunk_index),
@@ -44,6 +59,10 @@ class ConfigGenerator:
             "attachments": [],
             "metadata": [],
         }
+
+        # TODO: Add log mappings once we determine the correct format for tabular2mcap
+        # if include_log:
+        #     config["log_mappings"] = self._generate_log_mappings()
 
         logger.debug(f"Generated config for chunk {chunk_index}: "
                     f"{len(config['tabular_mappings'])} tabular, "
@@ -54,9 +73,7 @@ class ConfigGenerator:
     def _generate_tabular_mappings(self, chunk_index: int) -> list[dict]:
         """
         Generate tabular mapping configurations.
-
         Creates mappings for parquet data files.
-
         Args:
             chunk_index: The chunk index
 
@@ -65,17 +82,10 @@ class ConfigGenerator:
         """
         mappings = []
 
-        # Parquet file mapping
-        data_path_template = self.dataset_info.data.get(
-            "data_path",
-            "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet"
-        )
-        # Format chunk_index but keep file_index as wildcard
-        # Replace {chunk_index:03d} with actual value, and {file_index:03d} with *
-        parquet_pattern = data_path_template.replace(
-            "{chunk_index:03d}", f"{chunk_index:03d}"
-        ).replace(
-            "{file_index:03d}", "*"
+        # Generate parquet file pattern using helper
+        parquet_pattern = self._format_file_pattern(
+            self.dataset_info.data_path_template,
+            chunk_index
         )
 
         mappings.append({
@@ -95,7 +105,6 @@ class ConfigGenerator:
     def _generate_video_mappings(self, chunk_index: int) -> list[dict]:
         """
         Generate video mapping configurations for all video streams.
-
         Args:
             chunk_index: The chunk index
 
@@ -103,31 +112,16 @@ class ConfigGenerator:
             List of CompressedVideoMappingConfig dictionaries
         """
         mappings = []
-        video_path_template = self.dataset_info.data.get(
-            "video_path",
-            "videos/{video_key}/chunk-{chunk_index:03d}/file-{file_index:03d}.mp4"
-        )
 
         for video_key in self.dataset_info.video_keys:
-            # Get codec for this video stream
-            codec = self.dataset_info.get_video_codec(video_key)
+            # Get codec for this video stream (already returns valid format or default)
+            video_format = self.dataset_info.get_video_codec(video_key)
 
-            # Map LeRobot codec names to tabular2mcap format names
-            codec_map = {
-                "av1": "av1",
-                "h264": "h264",
-                "h265": "h265",
-                "vp9": "vp9",
-            }
-            video_format = codec_map.get(codec, "h264")
-
-            # Generate file pattern for this video stream
-            # Replace placeholders: {video_key}, {chunk_index:03d}, {file_index:03d}
-            video_pattern = (
-                video_path_template
-                .replace("{video_key}", video_key)
-                .replace("{chunk_index:03d}", f"{chunk_index:03d}")
-                .replace("{file_index:03d}", "*")
+            # Generate video file pattern using helper
+            video_pattern = self._format_file_pattern(
+                self.dataset_info.video_path_template,
+                chunk_index,
+                video_key=video_key
             )
 
             # Generate topic suffix from video_key
@@ -150,10 +144,8 @@ class ConfigGenerator:
     def _generate_log_mappings(self) -> list[dict]:
         """
         Generate log mapping configurations for terminal output logs.
-
         Uses tabular2mcap's built-in LogConverter to parse raw .log files
         directly into rcl_interfaces/msg/Log messages.
-
         Returns:
             List of LogMappingConfig dictionaries
         """
@@ -168,10 +160,8 @@ class ConfigGenerator:
     def generate_config_summary(self, chunk_index: int) -> str:
         """
         Generate a human-readable summary of the configuration.
-
         Args:
             chunk_index: The chunk index
-
         Returns:
             Formatted string describing the configuration
         """
@@ -186,11 +176,14 @@ class ConfigGenerator:
         for i, mapping in enumerate(config['tabular_mappings'], 1):
             summary.append(f"    {i}. {mapping['file_pattern']}")
 
-        summary.append(f"  Video mappings: {len(config['other_mappings'])}")
+        summary.append(f"  Other mappings: {len(config['other_mappings'])}")
         for i, mapping in enumerate(config['other_mappings'], 1):
-            summary.append(
-                f"    {i}. {mapping['topic_suffix']} "
-                f"({mapping['format']}, frame_id={mapping['frame_id']})"
-            )
+            mapping_type = mapping.get('type', 'unknown')
+            topic = mapping.get('topic_suffix', 'N/A')
+            if mapping_type == 'compressed_video':
+                details = f"{topic} ({mapping['format']}, frame_id={mapping['frame_id']})"
+            else:
+                details = topic
+            summary.append(f"    {i}. [{mapping_type}] {details}")
 
         return "\n".join(summary)

--- a/lerobot2mcap/config_generator.py
+++ b/lerobot2mcap/config_generator.py
@@ -38,6 +38,22 @@ class ConfigGenerator:
         formatted = formatted.replace("file-000", "file-*")
         return formatted
 
+    @staticmethod
+    def _format_episode_pattern(template: str, chunk_index: int, episode_index: int, **kwargs) -> str:
+        """
+        Format a file path template for a specific episode (no wildcards).
+        Args:
+            template: Path template with placeholders (e.g., "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet")
+            chunk_index: The chunk index to substitute
+            episode_index: The episode index to use as file_index
+            **kwargs: Additional key-value pairs to substitute in the template
+        Returns:
+            Formatted pattern with specific file path (e.g., "data/chunk-000/file-002.parquet")
+        """
+        # Format with specific file_index (episode_index)
+        formatted = template.format(chunk_index=chunk_index, file_index=episode_index, **kwargs)
+        return formatted
+
     def generate_chunk_config(self, chunk_index: int, include_log: bool = False) -> dict:
         """
         Generate configuration dictionary for a specific chunk.
@@ -65,6 +81,33 @@ class ConfigGenerator:
         #     config["log_mappings"] = self._generate_log_mappings()
 
         logger.debug(f"Generated config for chunk {chunk_index}: "
+                    f"{len(config['tabular_mappings'])} tabular, "
+                    f"{len(config['other_mappings'])} other mappings")
+
+        return config
+
+    def generate_episode_config(self, episode_index: int, chunk_index: int, include_log: bool = False) -> dict:
+        """
+        Generate configuration dictionary for a specific episode.
+        Args:
+            episode_index: The episode index (used as file_index in paths)
+            chunk_index: The chunk index
+            include_log: Whether to include log file mapping
+        Returns:
+            Configuration dictionary compatible with McapConversionConfig
+        """
+        # Video mappings go in other_mappings
+        other_mappings = self._generate_video_mappings_for_episode(episode_index, chunk_index)
+
+        config = {
+            "writer_format": "ros2",
+            "tabular_mappings": self._generate_tabular_mappings_for_episode(episode_index, chunk_index),
+            "other_mappings": other_mappings,
+            "attachments": [],
+            "metadata": [],
+        }
+
+        logger.debug(f"Generated config for episode {episode_index} in chunk {chunk_index}: "
                     f"{len(config['tabular_mappings'])} tabular, "
                     f"{len(config['other_mappings'])} other mappings")
 
@@ -102,6 +145,39 @@ class ConfigGenerator:
 
         return mappings
 
+    def _generate_tabular_mappings_for_episode(self, episode_index: int, chunk_index: int) -> list[dict]:
+        """
+        Generate tabular mapping configurations for a specific episode.
+        Creates mappings for a specific parquet data file (not wildcards).
+        Args:
+            episode_index: The episode index (used as file_index)
+            chunk_index: The chunk index
+        Returns:
+            List of tabular mapping configurations
+        """
+        mappings = []
+
+        # Generate parquet file pattern for specific episode (no wildcards)
+        parquet_pattern = self._format_episode_pattern(
+            self.dataset_info.data_path_template,
+            chunk_index,
+            episode_index
+        )
+
+        mappings.append({
+            "file_pattern": f"**/{parquet_pattern}",
+            "converter_functions": [
+                {
+                    "function_name": "row_to_message_with_timestamp",
+                    "schema_name": None,  # Will auto-generate schema
+                    "topic_suffix": "robot_data",
+                    "exclude_columns": ["timestamp"],
+                }
+            ],
+        })
+
+        return mappings
+
     def _generate_video_mappings(self, chunk_index: int) -> list[dict]:
         """
         Generate video mapping configurations for all video streams.
@@ -121,6 +197,46 @@ class ConfigGenerator:
             video_pattern = self._format_file_pattern(
                 self.dataset_info.video_path_template,
                 chunk_index,
+                video_key=video_key
+            )
+
+            # Generate topic suffix from video_key
+            # "observation.images.front" -> "observation/images/front"
+            topic_suffix = video_key.replace(".", "/")
+
+            # Get frame_id
+            frame_id = self.dataset_info.get_video_frame_id(video_key)
+
+            mappings.append({
+                "type": "compressed_video",
+                "file_pattern": f"**/{video_pattern}",
+                "topic_suffix": topic_suffix,
+                "frame_id": frame_id,
+                "format": video_format,
+            })
+
+        return mappings
+
+    def _generate_video_mappings_for_episode(self, episode_index: int, chunk_index: int) -> list[dict]:
+        """
+        Generate video mapping configurations for a specific episode.
+        Args:
+            episode_index: The episode index (used as file_index)
+            chunk_index: The chunk index
+        Returns:
+            List of CompressedVideoMappingConfig dictionaries
+        """
+        mappings = []
+
+        for video_key in self.dataset_info.video_keys:
+            # Get codec for this video stream
+            video_format = self.dataset_info.get_video_codec(video_key)
+
+            # Generate video file pattern for specific episode (no wildcards)
+            video_pattern = self._format_episode_pattern(
+                self.dataset_info.video_path_template,
+                chunk_index,
+                episode_index,
                 video_key=video_key
             )
 

--- a/lerobot2mcap/config_generator.py
+++ b/lerobot2mcap/config_generator.py
@@ -1,7 +1,7 @@
 """Configuration generator for tabular2mcap conversion."""
 
 import logging
-from pathlib import Path
+# from pathlib import Path TO DO: check why currently this is unused
 
 from .dataset_info import DatasetInfo
 
@@ -18,56 +18,83 @@ class ConfigGenerator:
             dataset_info: DatasetInfo instance containing dataset metadata
         """
         self.dataset_info = dataset_info
-        logger.info(f"Initialized ConfigGenerator for dataset with {len(dataset_info.video_keys)} video streams")
+        logger.info(
+            f"Initialized ConfigGenerator for dataset with {len(dataset_info.video_keys)} video streams"
+        )
 
     @staticmethod
     def _format_file_pattern(template: str, chunk_index: int, **kwargs) -> str:
         """
         Format a file path template for a specific chunk, converting file_index to wildcard.
+        Supports both v2.1 and v3 LeRobot formats.
         Args:
-            template: Path template with placeholders (e.g., "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet")
+            template: Path template with placeholders
             chunk_index: The chunk index to substitute
             **kwargs: Additional key-value pairs to substitute in the template
         Returns:
             Formatted pattern with chunk_index filled and file_index as wildcard
         """
-        # First format the chunk_index and any other kwargs
-        formatted = template.format(chunk_index=chunk_index, file_index=0, **kwargs)
-        # Then replace the formatted file_index (000) with wildcard
-        # This assumes file_index uses :03d format
-        formatted = formatted.replace("file-000", "file-*")
+        # Support both v2.1 and v3 naming conventions
+        format_params = {
+            "episode_chunk": chunk_index,  # v2.1 format
+            "episode_index": 0,  # v2.1 format
+            "chunk_index": chunk_index,  # v3 format
+            "file_index": 0,  # v3 format
+            **kwargs,
+        }
+
+        # Format the template with all parameters
+        formatted = template.format(**format_params)
+
+        # Replace file index with wildcard (supports both formats)
+        formatted = formatted.replace(
+            "episode_000000", "episode_*"
+        )  # v2.1: episode_{episode_index:06d}
+        formatted = formatted.replace("file-000", "file-*")  # v3: file-{file_index:03d}
+
         return formatted
 
     @staticmethod
-    def _format_episode_pattern(template: str, chunk_index: int, episode_index: int, **kwargs) -> str:
+    def _format_episode_pattern(
+        template: str, chunk_index: int, episode_index: int, **kwargs
+    ) -> str:
         """
         Format a file path template for a specific episode (no wildcards).
+        Supports both v2.1 and v3 LeRobot formats.
         Args:
-            template: Path template with placeholders (e.g., "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet")
+            template: Path template with placeholders
             chunk_index: The chunk index to substitute
             episode_index: The episode index to use as file_index
             **kwargs: Additional key-value pairs to substitute in the template
         Returns:
-            Formatted pattern with specific file path (e.g., "data/chunk-000/file-002.parquet")
+            Formatted pattern with specific file path
         """
+        # Support both v2.1 and v3 naming conventions
+        format_params = {
+            "episode_chunk": chunk_index,  # v2.1 format
+            "episode_index": episode_index,  # v2.1 format
+            "chunk_index": chunk_index,  # v3 format
+            "file_index": episode_index,  # v3 format
+            **kwargs,
+        }
+
         # Format with specific file_index (episode_index)
-        formatted = template.format(chunk_index=chunk_index, file_index=episode_index, **kwargs)
+        formatted = template.format(**format_params)
         return formatted
 
-    def generate_chunk_config(self, chunk_index: int, include_log: bool = False) -> dict:
+    def generate_chunk_config(self, chunk_index: int) -> dict:
         """
-        Generate configuration dictionary for a specific chunk.
+        Generate configuration dictionary for a whole (potentially multi-episode) specific chunk.
+
         Args:
             chunk_index: The chunk index to generate config for
-            include_log: Whether to include log file mapping
+
         Returns:
             Configuration dictionary compatible with McapConversionConfig
         """
         # Video mappings go in other_mappings
         other_mappings = self._generate_video_mappings(chunk_index)
 
-        # Log mappings go in a separate field (if tabular2mcap supports it)
-        # For now, we'll exclude logs to avoid validation errors
         config = {
             "writer_format": "ros2",
             "tabular_mappings": self._generate_tabular_mappings(chunk_index),
@@ -76,40 +103,60 @@ class ConfigGenerator:
             "metadata": [],
         }
 
-        # TODO: Add log mappings once we determine the correct format for tabular2mcap
-        # if include_log:
-        #     config["log_mappings"] = self._generate_log_mappings()
-
-        logger.debug(f"Generated config for chunk {chunk_index}: "
-                    f"{len(config['tabular_mappings'])} tabular, "
-                    f"{len(config['other_mappings'])} other mappings")
+        logger.debug(
+            f"Generated config for chunk {chunk_index}: "
+            f"{len(config['tabular_mappings'])} tabular, "
+            f"{len(config['other_mappings'])} other mappings"
+        )
 
         return config
 
-    def generate_episode_config(self, episode_index: int, chunk_index: int, include_log: bool = False) -> dict:
+    def generate_episode_config(
+        self, episode_index: int, chunk_index: int, include_log: bool = False
+    ) -> dict:
         """
         Generate configuration dictionary for a specific episode.
+
         Args:
             episode_index: The episode index (used as file_index in paths)
             chunk_index: The chunk index
-            include_log: Whether to include log file mapping
+            include_log: Whether to include log file as MCAP attachment
+
         Returns:
             Configuration dictionary compatible with McapConversionConfig
         """
         # Video mappings go in other_mappings
-        other_mappings = self._generate_video_mappings_for_episode(episode_index, chunk_index)
+        other_mappings = self._generate_video_mappings_for_episode(
+            episode_index, chunk_index
+        )
+
+        # Generate attachments (log file if requested)
+        attachments = []
+        if include_log:
+            attachments.append(
+                {
+                    "file_pattern": "**/*.log",
+                    "name": "dataset.log",
+                    "media_type": "text/plain",
+                }
+            )
 
         config = {
             "writer_format": "ros2",
-            "tabular_mappings": self._generate_tabular_mappings_for_episode(episode_index, chunk_index),
+            "tabular_mappings": self._generate_tabular_mappings_for_episode(
+                episode_index, chunk_index
+            ),
             "other_mappings": other_mappings,
-            "attachments": [],
+            "attachments": attachments,
             "metadata": [],
         }
 
-        logger.debug(f"Generated config for episode {episode_index} in chunk {chunk_index}: "
-                    f"{len(config['tabular_mappings'])} tabular, "
-                    f"{len(config['other_mappings'])} other mappings")
+        logger.debug(
+            f"Generated config for episode {episode_index} in chunk {chunk_index}: "
+            f"{len(config['tabular_mappings'])} tabular, "
+            f"{len(config['other_mappings'])} other mappings, "
+            f"{len(config['attachments'])} attachments"
+        )
 
         return config
 
@@ -127,25 +174,28 @@ class ConfigGenerator:
 
         # Generate parquet file pattern using helper
         parquet_pattern = self._format_file_pattern(
-            self.dataset_info.data_path_template,
-            chunk_index
+            self.dataset_info.data_path_template, chunk_index
         )
 
-        mappings.append({
-            "file_pattern": f"**/{parquet_pattern}",
-            "converter_functions": [
-                {
-                    "function_name": "row_to_message_with_timestamp",
-                    "schema_name": None,  # Will auto-generate schema
-                    "topic_suffix": "robot_data",
-                    "exclude_columns": ["timestamp"],
-                }
-            ],
-        })
+        mappings.append(
+            {
+                "file_pattern": f"**/{parquet_pattern}",
+                "converter_functions": [
+                    {
+                        "function_name": "row_to_message_with_timestamp",
+                        "schema_name": None,  # Will auto-generate schema
+                        "topic_suffix": "robot_data",
+                        "exclude_columns": ["timestamp"],
+                    }
+                ],
+            }
+        )
 
         return mappings
 
-    def _generate_tabular_mappings_for_episode(self, episode_index: int, chunk_index: int) -> list[dict]:
+    def _generate_tabular_mappings_for_episode(
+        self, episode_index: int, chunk_index: int
+    ) -> list[dict]:
         """
         Generate tabular mapping configurations for a specific episode.
         Creates mappings for a specific parquet data file (not wildcards).
@@ -159,22 +209,22 @@ class ConfigGenerator:
 
         # Generate parquet file pattern for specific episode (no wildcards)
         parquet_pattern = self._format_episode_pattern(
-            self.dataset_info.data_path_template,
-            chunk_index,
-            episode_index
+            self.dataset_info.data_path_template, chunk_index, episode_index
         )
 
-        mappings.append({
-            "file_pattern": f"**/{parquet_pattern}",
-            "converter_functions": [
-                {
-                    "function_name": "row_to_message_with_timestamp",
-                    "schema_name": None,  # Will auto-generate schema
-                    "topic_suffix": "robot_data",
-                    "exclude_columns": ["timestamp"],
-                }
-            ],
-        })
+        mappings.append(
+            {
+                "file_pattern": f"**/{parquet_pattern}",
+                "converter_functions": [
+                    {
+                        "function_name": "row_to_message_with_timestamp",
+                        "schema_name": None,  # Will auto-generate schema
+                        "topic_suffix": "robot_data",
+                        "exclude_columns": ["timestamp"],
+                    }
+                ],
+            }
+        )
 
         return mappings
 
@@ -195,9 +245,7 @@ class ConfigGenerator:
 
             # Generate video file pattern using helper
             video_pattern = self._format_file_pattern(
-                self.dataset_info.video_path_template,
-                chunk_index,
-                video_key=video_key
+                self.dataset_info.video_path_template, chunk_index, video_key=video_key
             )
 
             # Generate topic suffix from video_key
@@ -207,17 +255,21 @@ class ConfigGenerator:
             # Get frame_id
             frame_id = self.dataset_info.get_video_frame_id(video_key)
 
-            mappings.append({
-                "type": "compressed_video",
-                "file_pattern": f"**/{video_pattern}",
-                "topic_suffix": topic_suffix,
-                "frame_id": frame_id,
-                "format": video_format,
-            })
+            mappings.append(
+                {
+                    "type": "compressed_video",
+                    "file_pattern": f"**/{video_pattern}",
+                    "topic_suffix": topic_suffix,
+                    "frame_id": frame_id,
+                    "format": video_format,
+                }
+            )
 
         return mappings
 
-    def _generate_video_mappings_for_episode(self, episode_index: int, chunk_index: int) -> list[dict]:
+    def _generate_video_mappings_for_episode(
+        self, episode_index: int, chunk_index: int
+    ) -> list[dict]:
         """
         Generate video mapping configurations for a specific episode.
         Args:
@@ -237,7 +289,7 @@ class ConfigGenerator:
                 self.dataset_info.video_path_template,
                 chunk_index,
                 episode_index,
-                video_key=video_key
+                video_key=video_key,
             )
 
             # Generate topic suffix from video_key
@@ -247,41 +299,29 @@ class ConfigGenerator:
             # Get frame_id
             frame_id = self.dataset_info.get_video_frame_id(video_key)
 
-            mappings.append({
-                "type": "compressed_video",
-                "file_pattern": f"**/{video_pattern}",
-                "topic_suffix": topic_suffix,
-                "frame_id": frame_id,
-                "format": video_format,
-            })
+            mappings.append(
+                {
+                    "type": "compressed_video",
+                    "file_pattern": f"**/{video_pattern}",
+                    "topic_suffix": topic_suffix,
+                    "frame_id": frame_id,
+                    "format": video_format,
+                }
+            )
 
         return mappings
-
-    def _generate_log_mappings(self) -> list[dict]:
-        """
-        Generate log mapping configurations for terminal output logs.
-        Uses tabular2mcap's built-in LogConverter to parse raw .log files
-        directly into rcl_interfaces/msg/Log messages.
-        Returns:
-            List of LogMappingConfig dictionaries
-        """
-        return [{
-            "type": "log",
-            "file_pattern": "**/*.log",
-            "topic_suffix": "terminal_log",
-            "format_template": r"^(?P<levelname>INFO|DEBUG|WARNING|ERROR|FATAL)\s(?P<asctime>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2})\s(?P<filename>\S+):(?P<lineno>\d+)\s(?P<message>.*)$",
-            "datetime_format": "%Y-%m-%d %H:%M:%S",
-        }]
 
     def generate_config_summary(self, chunk_index: int) -> str:
         """
         Generate a human-readable summary of the configuration.
+
         Args:
             chunk_index: The chunk index
+
         Returns:
             Formatted string describing the configuration
         """
-        config = self.generate_chunk_config(chunk_index, include_log=True)
+        config = self.generate_chunk_config(chunk_index)
 
         summary = [
             f"Configuration for chunk-{chunk_index:03d}:",
@@ -289,15 +329,17 @@ class ConfigGenerator:
             f"  Tabular mappings: {len(config['tabular_mappings'])}",
         ]
 
-        for i, mapping in enumerate(config['tabular_mappings'], 1):
+        for i, mapping in enumerate(config["tabular_mappings"], 1):
             summary.append(f"    {i}. {mapping['file_pattern']}")
 
         summary.append(f"  Other mappings: {len(config['other_mappings'])}")
-        for i, mapping in enumerate(config['other_mappings'], 1):
-            mapping_type = mapping.get('type', 'unknown')
-            topic = mapping.get('topic_suffix', 'N/A')
-            if mapping_type == 'compressed_video':
-                details = f"{topic} ({mapping['format']}, frame_id={mapping['frame_id']})"
+        for i, mapping in enumerate(config["other_mappings"], 1):
+            mapping_type = mapping.get("type", "unknown")
+            topic = mapping.get("topic_suffix", "N/A")
+            if mapping_type == "compressed_video":
+                details = (
+                    f"{topic} ({mapping['format']}, frame_id={mapping['frame_id']})"
+                )
             else:
                 details = topic
             summary.append(f"    {i}. [{mapping_type}] {details}")

--- a/lerobot2mcap/config_generator.py
+++ b/lerobot2mcap/config_generator.py
@@ -11,7 +11,7 @@ from tabular2mcap.loader.models import (
     TabularMappingConfig,
 )
 
-from .dataset_info import DatasetInfo
+from .dataset_info import DEFAULT_CODEC, DatasetInfo
 
 logger = logging.getLogger(__name__)
 
@@ -176,8 +176,8 @@ class ConfigGenerator:
         mappings = []
 
         for video_key in self.dataset_info.video_keys:
-            # Get codec for this video stream
-            video_format = self.dataset_info.get_video_codec(video_key)
+            # Always use h264 codec for optimal speed
+            video_format = DEFAULT_CODEC
 
             # Generate video file pattern for specific episode (no wildcards)
             video_pattern = self._format_episode_pattern(

--- a/lerobot2mcap/config_generator.py
+++ b/lerobot2mcap/config_generator.py
@@ -2,7 +2,7 @@
 
 import logging
 
-# from pathlib import Path TO DO: check why currently this is unused
+# from pathlib import Path
 from tabular2mcap.loader.models import (
     AttachmentConfig,
     CompressedVideoMappingConfig,
@@ -32,10 +32,10 @@ class ConfigGenerator:
         """
         self.dataset_info = dataset_info
 
-        # Create a base template config with default values
+        # Create a base template config with default values from metadata
         # This will be copied and modified for each episode
         self._base_config_template = McapConversionConfig(
-            writer_format="ros2",
+            writer_format=dataset_info.get_writer_format(),
             tabular_mappings=[],
             other_mappings=[],
             attachments=[],

--- a/lerobot2mcap/config_generator.py
+++ b/lerobot2mcap/config_generator.py
@@ -1,7 +1,15 @@
 """Configuration generator for tabular2mcap conversion."""
 
 import logging
+
 # from pathlib import Path TO DO: check why currently this is unused
+from tabular2mcap.loader.models import (
+    AttachmentConfig,
+    CompressedVideoMappingConfig,
+    ConverterFunctionConfig,
+    McapConversionConfig,
+    TabularMappingConfig,
+)
 
 from .dataset_info import DatasetInfo
 
@@ -9,7 +17,12 @@ logger = logging.getLogger(__name__)
 
 
 class ConfigGenerator:
-    """Generates tabular2mcap configuration dynamically based on dataset info."""
+    """
+    Generates tabular2mcap configuration for each episodes based on metadata info.
+
+    Configurations are created per-episode (not per-chunk), with specific
+    file paths for each episode's data files, videos, and optional attachments.
+    """
 
     def __init__(self, dataset_info: DatasetInfo):
         """
@@ -18,41 +31,20 @@ class ConfigGenerator:
             dataset_info: DatasetInfo instance containing dataset metadata
         """
         self.dataset_info = dataset_info
+
+        # Create a base template config with default values
+        # This will be copied and modified for each episode
+        self._base_config_template = McapConversionConfig(
+            writer_format="ros2",
+            tabular_mappings=[],
+            other_mappings=[],
+            attachments=[],
+            metadata=[],
+        )
+
         logger.info(
             f"Initialized ConfigGenerator for dataset with {len(dataset_info.video_keys)} video streams"
         )
-
-    @staticmethod
-    def _format_file_pattern(template: str, chunk_index: int, **kwargs) -> str:
-        """
-        Format a file path template for a specific chunk, converting file_index to wildcard.
-        Supports both v2.1 and v3 LeRobot formats.
-        Args:
-            template: Path template with placeholders
-            chunk_index: The chunk index to substitute
-            **kwargs: Additional key-value pairs to substitute in the template
-        Returns:
-            Formatted pattern with chunk_index filled and file_index as wildcard
-        """
-        # Support both v2.1 and v3 naming conventions
-        format_params = {
-            "episode_chunk": chunk_index,  # v2.1 format
-            "episode_index": 0,  # v2.1 format
-            "chunk_index": chunk_index,  # v3 format
-            "file_index": 0,  # v3 format
-            **kwargs,
-        }
-
-        # Format the template with all parameters
-        formatted = template.format(**format_params)
-
-        # Replace file index with wildcard (supports both formats)
-        formatted = formatted.replace(
-            "episode_000000", "episode_*"
-        )  # v2.1: episode_{episode_index:06d}
-        formatted = formatted.replace("file-000", "file-*")  # v3: file-{file_index:03d}
-
-        return formatted
 
     @staticmethod
     def _format_episode_pattern(
@@ -82,40 +74,13 @@ class ConfigGenerator:
         formatted = template.format(**format_params)
         return formatted
 
-    def generate_chunk_config(self, chunk_index: int) -> dict:
-        """
-        Generate configuration dictionary for a whole (potentially multi-episode) specific chunk.
-
-        Args:
-            chunk_index: The chunk index to generate config for
-
-        Returns:
-            Configuration dictionary compatible with McapConversionConfig
-        """
-        # Video mappings go in other_mappings
-        other_mappings = self._generate_video_mappings(chunk_index)
-
-        config = {
-            "writer_format": "ros2",
-            "tabular_mappings": self._generate_tabular_mappings(chunk_index),
-            "other_mappings": other_mappings,
-            "attachments": [],
-            "metadata": [],
-        }
-
-        logger.debug(
-            f"Generated config for chunk {chunk_index}: "
-            f"{len(config['tabular_mappings'])} tabular, "
-            f"{len(config['other_mappings'])} other mappings"
-        )
-
-        return config
-
     def generate_episode_config(
         self, episode_index: int, chunk_index: int, include_log: bool = True
-    ) -> dict:
+    ) -> McapConversionConfig:
         """
-        Generate configuration dictionary for a specific episode.
+        Generate configuration for a specific episode using Pydantic models.
+
+        Builds from the base template and updates with episode-specific mappings.
 
         Args:
             episode_index: The episode index (used as file_index in paths)
@@ -124,9 +89,12 @@ class ConfigGenerator:
                 tabular2mcap will auto-detect if the file exists)
 
         Returns:
-            Configuration dictionary compatible with McapConversionConfig
+            McapConversionConfig Pydantic model with validated configuration
         """
-        # Video mappings go in other_mappings
+        # Generate episode-specific mappings
+        tabular_mappings = self._generate_tabular_mappings_for_episode(
+            episode_index, chunk_index
+        )
         other_mappings = self._generate_video_mappings_for_episode(
             episode_index, chunk_index
         )
@@ -135,68 +103,33 @@ class ConfigGenerator:
         attachments = []
         if include_log:
             attachments.append(
-                {
-                    "file_pattern": "**/*.log",
-                    "name": "dataset.log",
-                    "media_type": "text/plain",
-                }
+                AttachmentConfig(
+                    file_pattern="**/*.log",
+                    mime_type="text/plain",
+                )
             )
 
-        config = {
-            "writer_format": "ros2",
-            "tabular_mappings": self._generate_tabular_mappings_for_episode(
-                episode_index, chunk_index
-            ),
-            "other_mappings": other_mappings,
-            "attachments": attachments,
-            "metadata": [],
-        }
+        # Build from template using model_copy with updates
+        config = self._base_config_template.model_copy(
+            update={
+                "tabular_mappings": tabular_mappings,
+                "other_mappings": other_mappings,
+                "attachments": attachments,
+            }
+        )
 
         logger.debug(
             f"Generated config for episode {episode_index} in chunk {chunk_index}: "
-            f"{len(config['tabular_mappings'])} tabular, "
-            f"{len(config['other_mappings'])} other mappings, "
-            f"{len(config['attachments'])} attachments"
+            f"{len(config.tabular_mappings)} tabular, "
+            f"{len(config.other_mappings)} other mappings, "
+            f"{len(config.attachments)} attachments"
         )
 
         return config
 
-    def _generate_tabular_mappings(self, chunk_index: int) -> list[dict]:
-        """
-        Generate tabular mapping configurations.
-        Creates mappings for parquet data files.
-        Args:
-            chunk_index: The chunk index
-
-        Returns:
-            List of tabular mapping configurations
-        """
-        mappings = []
-
-        # Generate parquet file pattern using helper
-        parquet_pattern = self._format_file_pattern(
-            self.dataset_info.data_path_template, chunk_index
-        )
-
-        mappings.append(
-            {
-                "file_pattern": f"**/{parquet_pattern}",
-                "converter_functions": [
-                    {
-                        "function_name": "row_to_message_with_timestamp",
-                        "schema_name": None,  # Will auto-generate schema
-                        "topic_suffix": "robot_data",
-                        "exclude_columns": ["timestamp"],
-                    }
-                ],
-            }
-        )
-
-        return mappings
-
     def _generate_tabular_mappings_for_episode(
         self, episode_index: int, chunk_index: int
-    ) -> list[dict]:
+    ) -> list[TabularMappingConfig]:
         """
         Generate tabular mapping configurations for a specific episode.
         Creates mappings for a specific parquet data file (not wildcards).
@@ -204,7 +137,7 @@ class ConfigGenerator:
             episode_index: The episode index (used as file_index)
             chunk_index: The chunk index
         Returns:
-            List of tabular mapping configurations
+            List of tabular mapping configurations using Pydantic models
         """
         mappings = []
 
@@ -214,70 +147,31 @@ class ConfigGenerator:
         )
 
         mappings.append(
-            {
-                "file_pattern": f"**/{parquet_pattern}",
-                "converter_functions": [
-                    {
-                        "function_name": "row_to_message_with_timestamp",
-                        "schema_name": None,  # Will auto-generate schema
-                        "topic_suffix": "robot_data",
-                        "exclude_columns": ["timestamp"],
-                    }
+            TabularMappingConfig(
+                file_pattern=f"**/{parquet_pattern}",
+                converter_functions=[
+                    ConverterFunctionConfig(
+                        function_name="row_to_message_with_timestamp",
+                        schema_name=None,  # Will auto-generate schema
+                        topic_suffix="robot_data",
+                        exclude_columns=["timestamp"],
+                    )
                 ],
-            }
+            )
         )
-
-        return mappings
-
-    def _generate_video_mappings(self, chunk_index: int) -> list[dict]:
-        """
-        Generate video mapping configurations for all video streams.
-        Args:
-            chunk_index: The chunk index
-
-        Returns:
-            List of CompressedVideoMappingConfig dictionaries
-        """
-        mappings = []
-
-        for video_key in self.dataset_info.video_keys:
-            # Get codec for this video stream (already returns valid format or default)
-            video_format = self.dataset_info.get_video_codec(video_key)
-
-            # Generate video file pattern using helper
-            video_pattern = self._format_file_pattern(
-                self.dataset_info.video_path_template, chunk_index, video_key=video_key
-            )
-
-            # Generate topic suffix from video_key
-            # "observation.images.front" -> "observation/images/front"
-            topic_suffix = video_key.replace(".", "/")
-
-            # Get frame_id
-            frame_id = self.dataset_info.get_video_frame_id(video_key)
-
-            mappings.append(
-                {
-                    "type": "compressed_video",
-                    "file_pattern": f"**/{video_pattern}",
-                    "topic_suffix": topic_suffix,
-                    "frame_id": frame_id,
-                    "format": video_format,
-                }
-            )
 
         return mappings
 
     def _generate_video_mappings_for_episode(
         self, episode_index: int, chunk_index: int
-    ) -> list[dict]:
+    ) -> list[CompressedVideoMappingConfig]:
         """
         Generate video mapping configurations for a specific episode.
         Args:
             episode_index: The episode index (used as file_index)
             chunk_index: The chunk index
         Returns:
-            List of CompressedVideoMappingConfig dictionaries
+            List of CompressedVideoMappingConfig Pydantic models
         """
         mappings = []
 
@@ -301,13 +195,12 @@ class ConfigGenerator:
             frame_id = self.dataset_info.get_video_frame_id(video_key)
 
             mappings.append(
-                {
-                    "type": "compressed_video",
-                    "file_pattern": f"**/{video_pattern}",
-                    "topic_suffix": topic_suffix,
-                    "frame_id": frame_id,
-                    "format": video_format,
-                }
+                CompressedVideoMappingConfig(
+                    file_pattern=f"**/{video_pattern}",
+                    topic_suffix=topic_suffix,
+                    frame_id=frame_id,
+                    format=video_format,
+                )
             )
 
         return mappings
@@ -316,33 +209,45 @@ class ConfigGenerator:
         """
         Generate a human-readable summary of the configuration.
 
+        Shows an example episode configuration (episode 0) to give users
+        a preview of what will be generated for each episode in the chunk.
+
         Args:
             chunk_index: The chunk index
 
         Returns:
             Formatted string describing the configuration
         """
-        config = self.generate_chunk_config(chunk_index)
+        # Generate an example config using episode 0
+        config = self.generate_episode_config(
+            episode_index=0, chunk_index=chunk_index, include_log=True
+        )
 
         summary = [
-            f"Configuration for chunk-{chunk_index:03d}:",
-            f"  Writer format: {config['writer_format']}",
-            f"  Tabular mappings: {len(config['tabular_mappings'])}",
+            f"Example configuration for chunk-{chunk_index:03d} (episode 0):",
+            f"  Writer format: {config.writer_format}",
+            f"  Tabular mappings: {len(config.tabular_mappings)}",
         ]
 
-        for i, mapping in enumerate(config["tabular_mappings"], 1):
-            summary.append(f"    {i}. {mapping['file_pattern']}")
+        for i, mapping in enumerate(config.tabular_mappings, 1):
+            summary.append(f"    {i}. {mapping.file_pattern}")
 
-        summary.append(f"  Other mappings: {len(config['other_mappings'])}")
-        for i, mapping in enumerate(config["other_mappings"], 1):
-            mapping_type = mapping.get("type", "unknown")
-            topic = mapping.get("topic_suffix", "N/A")
+        summary.append(f"  Other mappings: {len(config.other_mappings)}")
+        for i, mapping in enumerate(config.other_mappings, 1):
+            mapping_type = mapping.type if hasattr(mapping, "type") else "unknown"
+            topic = mapping.topic_suffix
             if mapping_type == "compressed_video":
-                details = (
-                    f"{topic} ({mapping['format']}, frame_id={mapping['frame_id']})"
-                )
+                details = f"{topic} ({mapping.format}, frame_id={mapping.frame_id})"
             else:
                 details = topic
             summary.append(f"    {i}. [{mapping_type}] {details}")
+
+        if config.attachments:
+            summary.append(f"  Attachments: {len(config.attachments)}")
+            for i, attachment in enumerate(config.attachments, 1):
+                mime_type = attachment.mime_type or "auto-detected"
+                summary.append(
+                    f"    {i}. {attachment.file_pattern} (MIME: {mime_type})"
+                )
 
         return "\n".join(summary)

--- a/lerobot2mcap/converter.py
+++ b/lerobot2mcap/converter.py
@@ -78,7 +78,10 @@ class LeRobotConverter:
         episodes: list[int] | None = None,
     ) -> bool:
         """
-        Convert the LeRobot dataset to MCAP format (episode-based).
+        Convert the LeRobot dataset to MCAP format.
+        Iterates through each chunk and converts all episodes within that chunk.
+        Each episode produces a separate MCAP file in its own directory.
+
         Args:
             output_dir: Directory where MCAP files will be saved
             chunks: List of chunk indices to convert (None = all chunks)
@@ -87,7 +90,7 @@ class LeRobotConverter:
             True if conversion succeeded, False otherwise
         """
         logger.info("=" * SEPARATOR_WIDTH)
-        logger.info("LeRobot to MCAP Conversion (Episode-Based)")
+        logger.info("LeRobot to MCAP Conversion")
         logger.info("=" * SEPARATOR_WIDTH)
         logger.info(f"Dataset: {self.dataset_root}")
         logger.info(f"Output: {output_dir}")
@@ -142,61 +145,6 @@ class LeRobotConverter:
         logger.info("=" * SEPARATOR_WIDTH)
 
         return success_count > 0
-
-    def _convert_chunk(
-        self, chunk_idx: int, output_dir: Path, include_log: bool
-    ):
-        """
-        Convert a single chunk to MCAP.
-        Args:
-            chunk_idx: The chunk index to convert
-            output_dir: Output directory for MCAP files
-            include_log: Whether to include log file in conversion
-        Raises:
-            Exception: If chunk conversion fails
-        """
-        # Check if chunk files exist
-        chunk_files = self.dataset_info.get_chunk_files(chunk_idx, self.dataset_root)
-
-        if not chunk_files["parquet"].exists():
-            raise FileNotFoundError(
-                f"Parquet file not found: {chunk_files['parquet']}"
-            )
-
-        # Check video files
-        missing_videos = []
-        for video_key, video_path in chunk_files["videos"].items():
-            if not video_path.exists():
-                missing_videos.append(video_key)
-
-        if missing_videos:
-            logger.warning(
-                f"Chunk {chunk_idx}: Missing videos: {missing_videos}. "
-                "These will be skipped."
-            )
-
-        # Generate dynamic configuration (tabular2mcap will find and parse .log files)
-        chunk_config = self.config_generator.generate_chunk_config(
-            chunk_idx, include_log=include_log
-        )
-
-        # Save config file alongside MCAP output
-        config_path = output_dir / f"chunk-{chunk_idx:03d}_config.yaml"
-        with open(config_path, "w") as config_file:
-            yaml.dump(chunk_config, config_file, default_flow_style=False, sort_keys=False)
-
-        logger.info(f"Saved config: {config_path.name}")
-
-        # Use tabular2mcap's McapConverter
-        mcap_converter = McapConverter(config_path, self.converter_functions_path)
-
-        # Output MCAP path
-        output_mcap = output_dir / f"chunk-{chunk_idx:03d}.mcap"
-
-        logger.info(f"Converting chunk {chunk_idx} -> {output_mcap.name}")
-
-        # Convert
-        mcap_converter.convert(self.dataset_root, output_mcap)
 
     def _convert_episode(
         self, episode_idx: int, chunk_idx: int, output_dir: Path, include_log: bool

--- a/lerobot2mcap/converter.py
+++ b/lerobot2mcap/converter.py
@@ -193,10 +193,14 @@ class LeRobotConverter:
         episode_dir.mkdir(parents=True, exist_ok=True)
 
         # Save config file: episode_000/config_000.yaml
+        # Convert Pydantic model to dict for YAML serialization
         config_path = episode_dir / f"config_{episode_idx:03d}.yaml"
         with open(config_path, "w") as config_file:
             yaml.dump(
-                episode_config, config_file, default_flow_style=False, sort_keys=False
+                episode_config.model_dump(mode="python", exclude_none=True),
+                config_file,
+                default_flow_style=False,
+                sort_keys=False,
             )
 
         logger.info(f"Saved config: {config_path.relative_to(output_dir)}")
@@ -236,14 +240,8 @@ class LeRobotConverter:
             f"Video streams: {len(self.dataset_info.video_keys)}",
         ]
 
-        for video_key in self.dataset_info.video_keys:
-            codec = self.dataset_info.get_video_codec(video_key)
-            plan.append(f"  - {video_key} ({codec})")
-
         plan.extend(
             [
-                f"Log file: {'Yes' if self.log_file else 'No'}",
-                "",
                 f"Chunks to convert: {len(chunks)}",
                 "",
             ]

--- a/lerobot2mcap/converter.py
+++ b/lerobot2mcap/converter.py
@@ -124,22 +124,24 @@ class LeRobotConverter:
         success_count = 0
         fail_count = 0
 
-        for chunk_idx in chunks:
-            for episode_idx in tqdm(
-                episodes,
-                desc=f"Converting episodes in chunk-{chunk_idx:03d}",
-                unit="episode",
-            ):
-                try:
-                    self._convert_episode(
-                        episode_idx, chunk_idx, output_dir, include_log
-                    )
-                    success_count += 1
-                except Exception as e:
-                    logger.warning(
-                        f"Skipping episode {episode_idx} in chunk {chunk_idx}: {e}"
-                    )
-                    fail_count += 1
+        # Create a flat list of (chunk_idx, episode_idx) pairs for all conversions
+        all_conversions = [
+            (chunk_idx, episode_idx) for chunk_idx in chunks for episode_idx in episodes
+        ]
+
+        for chunk_idx, episode_idx in tqdm(
+            all_conversions,
+            desc="Converting episodes",
+            unit="episode",
+        ):
+            try:
+                self._convert_episode(episode_idx, chunk_idx, output_dir, include_log)
+                success_count += 1
+            except Exception as e:
+                logger.warning(
+                    f"Skipping episode {episode_idx} in chunk {chunk_idx}: {e}"
+                )
+                fail_count += 1
 
         # Summary
         logger.info("=" * SEPARATOR_WIDTH)

--- a/lerobot2mcap/converter.py
+++ b/lerobot2mcap/converter.py
@@ -1,0 +1,239 @@
+"""Main converter orchestrator for LeRobot to MCAP conversion."""
+
+import logging
+import tempfile
+from pathlib import Path
+
+import yaml
+from tabular2mcap import McapConverter
+from tqdm import tqdm
+
+from .config_generator import ConfigGenerator
+from .dataset_info import DatasetInfo
+
+logger = logging.getLogger(__name__)
+
+
+class LeRobotConverter:
+    """Main converter orchestrator that manages the conversion process."""
+
+    def __init__(self, dataset_root: Path, converter_functions_path: Path):
+        """
+        Initialize LeRobotConverter.
+
+        Args:
+            dataset_root: Root directory of the LeRobot dataset
+            converter_functions_path: Path to converter_functions.yaml
+        """
+        self.dataset_root = dataset_root
+        self.converter_functions_path = converter_functions_path
+
+        # Validate dataset structure
+        info_json_path = dataset_root / "meta" / "info.json"
+        if not info_json_path.exists():
+            raise FileNotFoundError(
+                f"Dataset info.json not found at {info_json_path}. "
+                f"Is {dataset_root} a valid LeRobot dataset?"
+            )
+
+        # Composition: LeRobotConverter HAS-A DatasetInfo
+        self.dataset_info = DatasetInfo(info_json_path)
+
+        # Composition: LeRobotConverter HAS-A ConfigGenerator
+        self.config_generator = ConfigGenerator(self.dataset_info)
+
+        # Find log file
+        self.log_file = self._find_log_file()
+        if self.log_file:
+            logger.info(f"Found log file: {self.log_file}")
+        else:
+            logger.warning("No log file found in dataset root")
+
+        logger.info(f"Initialized converter for {self.dataset_info}")
+
+    def _find_log_file(self) -> Path | None:
+        """
+        Find the .log file in the dataset root directory.
+
+        Returns:
+            Path to the log file, or None if not found
+        """
+        log_files = list(self.dataset_root.glob("*.log"))
+
+        if not log_files:
+            return None
+
+        if len(log_files) > 1:
+            logger.warning(
+                f"Multiple log files found: {[f.name for f in log_files]}. "
+                f"Using the first one: {log_files[0].name}"
+            )
+
+        return log_files[0]
+
+    def convert(
+        self,
+        output_dir: Path,
+        chunks: list[int] | None = None,
+    ) -> bool:
+        """
+        Convert the LeRobot dataset to MCAP format.
+
+        Args:
+            output_dir: Directory where MCAP files will be saved
+            chunks: List of chunk indices to convert (None = all chunks)
+
+        Returns:
+            True if conversion succeeded, False otherwise
+        """
+        logger.info("=" * 60)
+        logger.info("LeRobot to MCAP Conversion")
+        logger.info("=" * 60)
+        logger.info(f"Dataset: {self.dataset_root}")
+        logger.info(f"Output: {output_dir}")
+        logger.info(f"Dataset info: {self.dataset_info}")
+
+        # Create output directory
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        # Determine which chunks to convert
+        if chunks is None:
+            total_chunks = self.dataset_info.get_total_chunks()
+            chunks = list(range(total_chunks))
+            logger.info(f"Converting all {total_chunks} chunks")
+        else:
+            logger.info(f"Converting chunks: {chunks}")
+
+        # Check if log file exists (tabular2mcap will handle parsing)
+        include_log = self.log_file is not None and self.log_file.exists()
+        if include_log and self.log_file:
+            logger.info(f"Log file will be included: {self.log_file.name}")
+
+        # Convert each chunk
+        success_count = 0
+        fail_count = 0
+
+        for chunk_idx in tqdm(chunks, desc="Converting chunks", unit="chunk"):
+            try:
+                self._convert_chunk(chunk_idx, output_dir, include_log)
+                success_count += 1
+            except Exception as e:
+                logger.warning(f"Skipping chunk {chunk_idx}: {e}")
+                fail_count += 1
+
+        # Summary
+        logger.info("=" * 60)
+        logger.info("Conversion Summary")
+        logger.info("=" * 60)
+        logger.info(f"Successfully converted: {success_count}/{len(chunks)} chunks")
+        if fail_count > 0:
+            logger.warning(f"Failed/Skipped: {fail_count}/{len(chunks)} chunks")
+        logger.info(f"Output directory: {output_dir}")
+        logger.info("=" * 60)
+
+        return success_count > 0
+
+    def _convert_chunk(
+        self, chunk_idx: int, output_dir: Path, include_log: bool
+    ):
+        """
+        Convert a single chunk to MCAP.
+
+        Args:
+            chunk_idx: The chunk index to convert
+            output_dir: Output directory for MCAP files
+            include_log: Whether to include log file in conversion
+
+        Raises:
+            Exception: If chunk conversion fails
+        """
+        # Check if chunk files exist
+        chunk_files = self.dataset_info.get_chunk_files(chunk_idx, self.dataset_root)
+
+        if not chunk_files["parquet"].exists():
+            raise FileNotFoundError(
+                f"Parquet file not found: {chunk_files['parquet']}"
+            )
+
+        # Check video files
+        missing_videos = []
+        for video_key, video_path in chunk_files["videos"].items():
+            if not video_path.exists():
+                missing_videos.append(video_key)
+
+        if missing_videos:
+            logger.warning(
+                f"Chunk {chunk_idx}: Missing videos: {missing_videos}. "
+                "These will be skipped."
+            )
+
+        # Generate dynamic configuration (tabular2mcap will find and parse .log files)
+        chunk_config = self.config_generator.generate_chunk_config(
+            chunk_idx, include_log=include_log
+        )
+
+        # Create temporary config file for tabular2mcap
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as config_file:
+            yaml.dump(chunk_config, config_file)
+            config_path = Path(config_file.name)
+
+        try:
+            # Use tabular2mcap's McapConverter
+            mcap_converter = McapConverter(config_path, self.converter_functions_path)
+
+            # Output MCAP path
+            output_mcap = output_dir / f"chunk-{chunk_idx:03d}.mcap"
+
+            logger.info(f"Converting chunk {chunk_idx} -> {output_mcap.name}")
+
+            # Convert
+            mcap_converter.convert(self.dataset_root, output_mcap)
+
+        finally:
+            # Clean up temporary config file
+            config_path.unlink(missing_ok=True)
+
+    def get_conversion_plan(self, chunks: list[int] | None = None) -> str:
+        """
+        Generate a human-readable conversion plan.
+
+        Args:
+            chunks: List of chunk indices to include in plan (None = all)
+
+        Returns:
+            Formatted string describing the conversion plan
+        """
+        if chunks is None:
+            chunks = list(range(self.dataset_info.get_total_chunks()))
+
+        plan = [
+            "=" * 60,
+            "LeRobot to MCAP Conversion Plan",
+            "=" * 60,
+            f"Dataset: {self.dataset_root.name}",
+            f"Total episodes: {self.dataset_info.get_total_episodes()}",
+            f"Total chunks: {self.dataset_info.get_total_chunks()}",
+            f"FPS: {self.dataset_info.get_fps()}",
+            f"Video streams: {len(self.dataset_info.video_keys)}",
+        ]
+
+        for video_key in self.dataset_info.video_keys:
+            codec = self.dataset_info.get_video_codec(video_key)
+            plan.append(f"  - {video_key} ({codec})")
+
+        plan.extend([
+            f"Log file: {'Yes' if self.log_file else 'No'}",
+            "",
+            f"Chunks to convert: {len(chunks)}",
+            "",
+        ])
+
+        # Show config for first chunk as example
+        if chunks:
+            plan.append(self.config_generator.generate_config_summary(chunks[0]))
+
+        plan.append("=" * 60)
+
+        return "\n".join(plan)

--- a/lerobot2mcap/converter.py
+++ b/lerobot2mcap/converter.py
@@ -75,17 +75,19 @@ class LeRobotConverter:
         self,
         output_dir: Path,
         chunks: list[int] | None = None,
+        episodes: list[int] | None = None,
     ) -> bool:
         """
-        Convert the LeRobot dataset to MCAP format.
+        Convert the LeRobot dataset to MCAP format (episode-based).
         Args:
             output_dir: Directory where MCAP files will be saved
             chunks: List of chunk indices to convert (None = all chunks)
+            episodes: List of episode indices to convert (None = all episodes)
         Returns:
             True if conversion succeeded, False otherwise
         """
         logger.info("=" * SEPARATOR_WIDTH)
-        logger.info("LeRobot to MCAP Conversion")
+        logger.info("LeRobot to MCAP Conversion (Episode-Based)")
         logger.info("=" * SEPARATOR_WIDTH)
         logger.info(f"Dataset: {self.dataset_root}")
         logger.info(f"Output: {output_dir}")
@@ -102,31 +104,40 @@ class LeRobotConverter:
         else:
             logger.info(f"Converting chunks: {chunks}")
 
+        # Determine which episodes to convert
+        if episodes is None:
+            total_episodes = self.dataset_info.get_total_episodes()
+            episodes = list(range(total_episodes))
+            logger.info(f"Converting all {total_episodes} episodes")
+        else:
+            logger.info(f"Converting episodes: {episodes}")
+
         # Check if log file exists (tabular2mcap will handle parsing)
         include_log = False
         if self.log_file is not None and self.log_file.exists():
             include_log = True
             logger.info(f"Log file will be included: {self.log_file.name}")
 
-        # Convert each chunk
+        # Convert each episode within each chunk
         success_count = 0
         fail_count = 0
 
-        for chunk_idx in tqdm(chunks, desc="Converting chunks", unit="chunk"):
-            try:
-                self._convert_chunk(chunk_idx, output_dir, include_log)
-                success_count += 1
-            except Exception as e:
-                logger.warning(f"Skipping chunk {chunk_idx}: {e}")
-                fail_count += 1
+        for chunk_idx in chunks:
+            for episode_idx in tqdm(episodes, desc=f"Converting episodes in chunk-{chunk_idx:03d}", unit="episode"):
+                try:
+                    self._convert_episode(episode_idx, chunk_idx, output_dir, include_log)
+                    success_count += 1
+                except Exception as e:
+                    logger.warning(f"Skipping episode {episode_idx} in chunk {chunk_idx}: {e}")
+                    fail_count += 1
 
         # Summary
         logger.info("=" * SEPARATOR_WIDTH)
         logger.info("Conversion Summary")
         logger.info("=" * SEPARATOR_WIDTH)
-        logger.info(f"Successfully converted: {success_count}/{len(chunks)} chunks")
+        logger.info(f"Successfully converted: {success_count} episodes")
         if fail_count > 0:
-            logger.warning(f"Failed/Skipped: {fail_count}/{len(chunks)} chunks")
+            logger.warning(f"Failed/Skipped: {fail_count} episodes")
         logger.info(f"Output directory: {output_dir}")
         logger.info("=" * SEPARATOR_WIDTH)
 
@@ -183,6 +194,66 @@ class LeRobotConverter:
         output_mcap = output_dir / f"chunk-{chunk_idx:03d}.mcap"
 
         logger.info(f"Converting chunk {chunk_idx} -> {output_mcap.name}")
+
+        # Convert
+        mcap_converter.convert(self.dataset_root, output_mcap)
+
+    def _convert_episode(
+        self, episode_idx: int, chunk_idx: int, output_dir: Path, include_log: bool
+    ):
+        """
+        Convert a single episode to MCAP.
+        Args:
+            episode_idx: The episode index (used as file_index)
+            chunk_idx: The chunk index
+            output_dir: Output directory for MCAP files
+            include_log: Whether to include log file in conversion
+        Raises:
+            Exception: If episode conversion fails
+        """
+        # Check if episode files exist
+        episode_files = self.dataset_info.get_episode_files(episode_idx, chunk_idx, self.dataset_root)
+
+        if not episode_files["parquet"].exists():
+            raise FileNotFoundError(
+                f"Parquet file not found: {episode_files['parquet']}"
+            )
+
+        # Check video files
+        missing_videos = []
+        for video_key, video_path in episode_files["videos"].items():
+            if not video_path.exists():
+                missing_videos.append(video_key)
+
+        if missing_videos:
+            logger.warning(
+                f"Episode {episode_idx}: Missing videos: {missing_videos}. "
+                "These will be skipped."
+            )
+
+        # Generate dynamic configuration for this episode
+        episode_config = self.config_generator.generate_episode_config(
+            episode_idx, chunk_idx, include_log=include_log
+        )
+
+        # Create episode directory: mcap_output/episode_000/
+        episode_dir = output_dir / f"episode_{episode_idx:03d}"
+        episode_dir.mkdir(parents=True, exist_ok=True)
+
+        # Save config file: episode_000/config_000.yaml
+        config_path = episode_dir / f"config_{episode_idx:03d}.yaml"
+        with open(config_path, "w") as config_file:
+            yaml.dump(episode_config, config_file, default_flow_style=False, sort_keys=False)
+
+        logger.info(f"Saved config: {config_path.relative_to(output_dir)}")
+
+        # Use tabular2mcap's McapConverter
+        mcap_converter = McapConverter(config_path, self.converter_functions_path)
+
+        # Output MCAP path: episode_000/episode_000.mcap
+        output_mcap = episode_dir / f"episode_{episode_idx:03d}.mcap"
+
+        logger.info(f"Converting episode {episode_idx} -> {output_mcap.relative_to(output_dir)}")
 
         # Convert
         mcap_converter.convert(self.dataset_root, output_mcap)

--- a/lerobot2mcap/converter.py
+++ b/lerobot2mcap/converter.py
@@ -47,7 +47,7 @@ class LeRobotConverter:
         if self.log_file:
             logger.info(f"Found log file: {self.log_file}")
         else:
-            logger.warning("No log file found in dataset root")
+            logger.info("No log file found in dataset root")
 
         logger.info(f"Initialized converter for {self.dataset_info}")
 
@@ -114,12 +114,6 @@ class LeRobotConverter:
         else:
             logger.info(f"Converting episodes: {episodes}")
 
-        # Check if log file exists (tabular2mcap will handle parsing)
-        include_log = False
-        if self.log_file is not None and self.log_file.exists():
-            include_log = True
-            logger.info(f"Log file will be included: {self.log_file.name}")
-
         # Convert each episode within each chunk
         success_count = 0
         fail_count = 0
@@ -135,7 +129,7 @@ class LeRobotConverter:
             unit="episode",
         ):
             try:
-                self._convert_episode(episode_idx, chunk_idx, output_dir, include_log)
+                self._convert_episode(episode_idx, chunk_idx, output_dir)
                 success_count += 1
             except Exception as e:
                 logger.warning(
@@ -156,7 +150,7 @@ class LeRobotConverter:
         return success_count > 0
 
     def _convert_episode(
-        self, episode_idx: int, chunk_idx: int, output_dir: Path, include_log: bool
+        self, episode_idx: int, chunk_idx: int, output_dir: Path
     ):
         """
         Convert a single episode to MCAP.
@@ -164,7 +158,6 @@ class LeRobotConverter:
             episode_idx: The episode index (used as file_index)
             chunk_idx: The chunk index
             output_dir: Output directory for MCAP files
-            include_log: Whether to include log file in conversion
         Raises:
             Exception: If episode conversion fails
         """
@@ -192,7 +185,7 @@ class LeRobotConverter:
 
         # Generate dynamic configuration for this episode
         episode_config = self.config_generator.generate_episode_config(
-            episode_idx, chunk_idx, include_log=include_log
+            episode_idx, chunk_idx
         )
 
         # Create episode directory: mcap_output/episode_000/

--- a/lerobot2mcap/converter.py
+++ b/lerobot2mcap/converter.py
@@ -1,7 +1,6 @@
 """Main converter orchestrator for LeRobot to MCAP conversion."""
 
 import logging
-import tempfile
 from pathlib import Path
 
 import yaml
@@ -13,6 +12,9 @@ from .dataset_info import DatasetInfo
 
 logger = logging.getLogger(__name__)
 
+# Display formatting constants
+SEPARATOR_WIDTH = 60
+
 
 class LeRobotConverter:
     """Main converter orchestrator that manages the conversion process."""
@@ -20,7 +22,6 @@ class LeRobotConverter:
     def __init__(self, dataset_root: Path, converter_functions_path: Path):
         """
         Initialize LeRobotConverter.
-
         Args:
             dataset_root: Root directory of the LeRobot dataset
             converter_functions_path: Path to converter_functions.yaml
@@ -54,7 +55,6 @@ class LeRobotConverter:
     def _find_log_file(self) -> Path | None:
         """
         Find the .log file in the dataset root directory.
-
         Returns:
             Path to the log file, or None if not found
         """
@@ -78,17 +78,15 @@ class LeRobotConverter:
     ) -> bool:
         """
         Convert the LeRobot dataset to MCAP format.
-
         Args:
             output_dir: Directory where MCAP files will be saved
             chunks: List of chunk indices to convert (None = all chunks)
-
         Returns:
             True if conversion succeeded, False otherwise
         """
-        logger.info("=" * 60)
+        logger.info("=" * SEPARATOR_WIDTH)
         logger.info("LeRobot to MCAP Conversion")
-        logger.info("=" * 60)
+        logger.info("=" * SEPARATOR_WIDTH)
         logger.info(f"Dataset: {self.dataset_root}")
         logger.info(f"Output: {output_dir}")
         logger.info(f"Dataset info: {self.dataset_info}")
@@ -105,8 +103,9 @@ class LeRobotConverter:
             logger.info(f"Converting chunks: {chunks}")
 
         # Check if log file exists (tabular2mcap will handle parsing)
-        include_log = self.log_file is not None and self.log_file.exists()
-        if include_log and self.log_file:
+        include_log = False
+        if self.log_file is not None and self.log_file.exists():
+            include_log = True
             logger.info(f"Log file will be included: {self.log_file.name}")
 
         # Convert each chunk
@@ -122,14 +121,14 @@ class LeRobotConverter:
                 fail_count += 1
 
         # Summary
-        logger.info("=" * 60)
+        logger.info("=" * SEPARATOR_WIDTH)
         logger.info("Conversion Summary")
-        logger.info("=" * 60)
+        logger.info("=" * SEPARATOR_WIDTH)
         logger.info(f"Successfully converted: {success_count}/{len(chunks)} chunks")
         if fail_count > 0:
             logger.warning(f"Failed/Skipped: {fail_count}/{len(chunks)} chunks")
         logger.info(f"Output directory: {output_dir}")
-        logger.info("=" * 60)
+        logger.info("=" * SEPARATOR_WIDTH)
 
         return success_count > 0
 
@@ -138,12 +137,10 @@ class LeRobotConverter:
     ):
         """
         Convert a single chunk to MCAP.
-
         Args:
             chunk_idx: The chunk index to convert
             output_dir: Output directory for MCAP files
             include_log: Whether to include log file in conversion
-
         Raises:
             Exception: If chunk conversion fails
         """
@@ -172,36 +169,29 @@ class LeRobotConverter:
             chunk_idx, include_log=include_log
         )
 
-        # Create temporary config file for tabular2mcap
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".yaml", delete=False
-        ) as config_file:
-            yaml.dump(chunk_config, config_file)
-            config_path = Path(config_file.name)
+        # Save config file alongside MCAP output
+        config_path = output_dir / f"chunk-{chunk_idx:03d}_config.yaml"
+        with open(config_path, "w") as config_file:
+            yaml.dump(chunk_config, config_file, default_flow_style=False, sort_keys=False)
 
-        try:
-            # Use tabular2mcap's McapConverter
-            mcap_converter = McapConverter(config_path, self.converter_functions_path)
+        logger.info(f"Saved config: {config_path.name}")
 
-            # Output MCAP path
-            output_mcap = output_dir / f"chunk-{chunk_idx:03d}.mcap"
+        # Use tabular2mcap's McapConverter
+        mcap_converter = McapConverter(config_path, self.converter_functions_path)
 
-            logger.info(f"Converting chunk {chunk_idx} -> {output_mcap.name}")
+        # Output MCAP path
+        output_mcap = output_dir / f"chunk-{chunk_idx:03d}.mcap"
 
-            # Convert
-            mcap_converter.convert(self.dataset_root, output_mcap)
+        logger.info(f"Converting chunk {chunk_idx} -> {output_mcap.name}")
 
-        finally:
-            # Clean up temporary config file
-            config_path.unlink(missing_ok=True)
+        # Convert
+        mcap_converter.convert(self.dataset_root, output_mcap)
 
     def get_conversion_plan(self, chunks: list[int] | None = None) -> str:
         """
         Generate a human-readable conversion plan.
-
         Args:
             chunks: List of chunk indices to include in plan (None = all)
-
         Returns:
             Formatted string describing the conversion plan
         """
@@ -209,9 +199,9 @@ class LeRobotConverter:
             chunks = list(range(self.dataset_info.get_total_chunks()))
 
         plan = [
-            "=" * 60,
+            "=" * SEPARATOR_WIDTH,
             "LeRobot to MCAP Conversion Plan",
-            "=" * 60,
+            "=" * SEPARATOR_WIDTH,
             f"Dataset: {self.dataset_root.name}",
             f"Total episodes: {self.dataset_info.get_total_episodes()}",
             f"Total chunks: {self.dataset_info.get_total_chunks()}",
@@ -234,6 +224,6 @@ class LeRobotConverter:
         if chunks:
             plan.append(self.config_generator.generate_config_summary(chunks[0]))
 
-        plan.append("=" * 60)
+        plan.append("=" * SEPARATOR_WIDTH)
 
         return "\n".join(plan)

--- a/lerobot2mcap/converter.py
+++ b/lerobot2mcap/converter.py
@@ -29,7 +29,6 @@ class LeRobotConverter:
         self.dataset_root = dataset_root
         self.converter_functions_path = converter_functions_path
 
-        # Validate dataset structure
         info_json_path = dataset_root / "meta" / "info.json"
         if not info_json_path.exists():
             raise FileNotFoundError(
@@ -37,10 +36,10 @@ class LeRobotConverter:
                 f"Is {dataset_root} a valid LeRobot dataset?"
             )
 
-        # Composition: LeRobotConverter HAS-A DatasetInfo
+        # Import Dataset Info from dataset_info.py
         self.dataset_info = DatasetInfo(info_json_path)
 
-        # Composition: LeRobotConverter HAS-A ConfigGenerator
+        # Import Config Generator from config_generator.py
         self.config_generator = ConfigGenerator(self.dataset_info)
 
         # Find log file
@@ -126,12 +125,20 @@ class LeRobotConverter:
         fail_count = 0
 
         for chunk_idx in chunks:
-            for episode_idx in tqdm(episodes, desc=f"Converting episodes in chunk-{chunk_idx:03d}", unit="episode"):
+            for episode_idx in tqdm(
+                episodes,
+                desc=f"Converting episodes in chunk-{chunk_idx:03d}",
+                unit="episode",
+            ):
                 try:
-                    self._convert_episode(episode_idx, chunk_idx, output_dir, include_log)
+                    self._convert_episode(
+                        episode_idx, chunk_idx, output_dir, include_log
+                    )
                     success_count += 1
                 except Exception as e:
-                    logger.warning(f"Skipping episode {episode_idx} in chunk {chunk_idx}: {e}")
+                    logger.warning(
+                        f"Skipping episode {episode_idx} in chunk {chunk_idx}: {e}"
+                    )
                     fail_count += 1
 
         # Summary
@@ -160,7 +167,9 @@ class LeRobotConverter:
             Exception: If episode conversion fails
         """
         # Check if episode files exist
-        episode_files = self.dataset_info.get_episode_files(episode_idx, chunk_idx, self.dataset_root)
+        episode_files = self.dataset_info.get_episode_files(
+            episode_idx, chunk_idx, self.dataset_root
+        )
 
         if not episode_files["parquet"].exists():
             raise FileNotFoundError(
@@ -191,7 +200,9 @@ class LeRobotConverter:
         # Save config file: episode_000/config_000.yaml
         config_path = episode_dir / f"config_{episode_idx:03d}.yaml"
         with open(config_path, "w") as config_file:
-            yaml.dump(episode_config, config_file, default_flow_style=False, sort_keys=False)
+            yaml.dump(
+                episode_config, config_file, default_flow_style=False, sort_keys=False
+            )
 
         logger.info(f"Saved config: {config_path.relative_to(output_dir)}")
 
@@ -201,7 +212,9 @@ class LeRobotConverter:
         # Output MCAP path: episode_000/episode_000.mcap
         output_mcap = episode_dir / f"episode_{episode_idx:03d}.mcap"
 
-        logger.info(f"Converting episode {episode_idx} -> {output_mcap.relative_to(output_dir)}")
+        logger.info(
+            f"Converting episode {episode_idx} -> {output_mcap.relative_to(output_dir)}"
+        )
 
         # Convert
         mcap_converter.convert(self.dataset_root, output_mcap)
@@ -232,12 +245,14 @@ class LeRobotConverter:
             codec = self.dataset_info.get_video_codec(video_key)
             plan.append(f"  - {video_key} ({codec})")
 
-        plan.extend([
-            f"Log file: {'Yes' if self.log_file else 'No'}",
-            "",
-            f"Chunks to convert: {len(chunks)}",
-            "",
-        ])
+        plan.extend(
+            [
+                f"Log file: {'Yes' if self.log_file else 'No'}",
+                "",
+                f"Chunks to convert: {len(chunks)}",
+                "",
+            ]
+        )
 
         # Show config for first chunk as example
         if chunks:

--- a/lerobot2mcap/dataset_info.py
+++ b/lerobot2mcap/dataset_info.py
@@ -283,45 +283,6 @@ class DatasetInfo:
         """
         return self.data.get("writer_format", "ros2")
 
-    def get_video_codec(self, video_key: str) -> str:
-        """
-        Get video codec for a specific video stream.
-
-        Looks up codec in features metadata for the given video_key.
-        Falls back to DEFAULT_CODEC if not specified.
-
-        Args:
-            video_key: The video key (e.g., "observation.images.front")
-
-        Returns:
-            Video codec (e.g., "h264", "h265", "vp9", "av1")
-
-        Raises:
-            KeyError: If 'features' field is missing from info.json
-        """
-        if "features" not in self.data:
-            raise KeyError(
-                f"Required field 'features' not found in {self.info_json_path}. "
-                "This field is required in LeRobot datasets."
-            )
-
-        features = self.data["features"]
-        if video_key in features:
-            video_info = features[video_key]
-            if isinstance(video_info, dict):
-                # Check in the 'info' sub-dict first (LeRobot v2.x/v3.x format)
-                if "info" in video_info and isinstance(video_info["info"], dict):
-                    codec = video_info["info"].get("video.codec", DEFAULT_CODEC)
-                else:
-                    codec = video_info.get("codec", DEFAULT_CODEC)
-
-                # Validate codec is one of the supported formats
-                if codec in ("h264", "h265", "vp9", "av1"):
-                    return codec
-
-        # Fallback to default codec
-        return DEFAULT_CODEC
-
     def get_video_frame_id(self, video_key: str) -> str:
         """
         Generate frame_id for a video stream.

--- a/lerobot2mcap/dataset_info.py
+++ b/lerobot2mcap/dataset_info.py
@@ -1,5 +1,24 @@
 """Dataset information parser for LeRobot datasets.
-Parses the info.json file to extract metadata about the dataset,"""
+Parses the info.json file to extract metadata about the dataset.
+
+TODO: v3.0 Episode Separation (Future PR)
+    LeRobot v3.0 datasets merge multiple episodes into single parquet/video files.
+    Current implementation assumes 1 episode = 1 file (v2.x behavior).
+    To support v3.0 properly:
+    1. Parse meta/episodes.jsonl to get episode boundaries (start_frame, length)
+    2. Filter parquet data by episode_index column before conversion
+    3. Implement video slicing by frame range (or reference frame indices in MCAP)
+    4. Update get_episode_files() to return frame ranges instead of file paths
+
+TODO: Boilerplate Reduction (Low Priority)
+    Consider using Pydantic model or __getattr__ to reduce repetitive getter methods.
+    See REVIEW.md for suggested approaches.
+
+TODO: Add validate_files() Method (Low Priority)
+    Optional method to verify files exist on disk before conversion:
+    def validate_files(self, dataset_root: Path) -> dict:
+        Returns {"missing_parquet": [...], "missing_videos": {...}, "extra_files": [...]}
+"""
 
 import json
 import logging

--- a/lerobot2mcap/dataset_info.py
+++ b/lerobot2mcap/dataset_info.py
@@ -11,8 +11,12 @@ logger = logging.getLogger(__name__)
 DEFAULT_FPS = 30
 DEFAULT_CODEC = "h264"
 DEFAULT_FILE_INDEX = 0  # First file in a chunk
-DEFAULT_DATA_PATH_TEMPLATE = "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet"
-DEFAULT_VIDEO_PATH_TEMPLATE = "videos/{video_key}/chunk-{chunk_index:03d}/file-{file_index:03d}.mp4"
+DEFAULT_DATA_PATH_TEMPLATE = (
+    "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet"
+)
+DEFAULT_VIDEO_PATH_TEMPLATE = (
+    "videos/{video_key}/chunk-{chunk_index:03d}/file-{file_index:03d}.mp4"
+)
 
 
 class DatasetInfo:
@@ -21,14 +25,24 @@ class DatasetInfo:
     def __init__(self, info_json_path: Path):
         """
         Initialize DatasetInfo by parsing info.json.
+
         Args:
             info_json_path: Path to the info.json file (usually in meta/info.json)
         """
-        self.info_json_path = info_json_path
-        self.data = self._parse_info_json()
-        self.video_keys = self._extract_video_keys()
-        logger.info(f"Loaded dataset info from {info_json_path}")
-        logger.info(f"Found {len(self.video_keys)} video streams: {self.video_keys}")
+        self.info_json_path = info_json_path  # Assign the info json address
+        self.data = (
+            self._parse_info_json()
+        )  # Load information from the info.json into the data member variable
+        self.video_keys = (
+            self._extract_video_keys()
+        )  # Extract keys of video dict - the names of your camera feeds
+
+        logger.info(
+            f"Loaded dataset info from {info_json_path}"
+        )  # Record info.json data extraction in file logs
+        logger.info(
+            f"Found {len(self.video_keys)} video streams: {self.video_keys}"
+        )  # Record number of keys and the key name strings
 
     def _parse_info_json(self) -> dict:
         """Parse the info.json file."""
@@ -72,9 +86,11 @@ class DatasetInfo:
     def get_chunk_files(self, chunk_index: int, dataset_root: Path) -> dict:
         """
         Get file paths for a specific chunk.
+
         Args:
             chunk_index: The chunk index (e.g., 0 for chunk-000)
             dataset_root: Root directory of the dataset
+
         Returns:
             Dictionary with:
             {
@@ -89,9 +105,12 @@ class DatasetInfo:
         chunk_files = {}
 
         # Get parquet file path using property (checks info.json with fallback)
+        # Support both v2.1 and v3 naming conventions
         parquet_path = self.data_path_template.format(
-            chunk_index=chunk_index,
-            file_index=DEFAULT_FILE_INDEX
+            episode_chunk=chunk_index,  # v2.1 format
+            episode_index=DEFAULT_FILE_INDEX,  # v2.1 format
+            chunk_index=chunk_index,  # v3 format
+            file_index=DEFAULT_FILE_INDEX,  # v3 format
         )
         chunk_files["parquet"] = dataset_root / parquet_path
 
@@ -99,22 +118,29 @@ class DatasetInfo:
         chunk_files["videos"] = {}
 
         for video_key in self.video_keys:
+            # Support both v2.1 and v3 naming conventions
             video_path = self.video_path_template.format(
                 video_key=video_key,
-                chunk_index=chunk_index,
-                file_index=DEFAULT_FILE_INDEX
+                episode_chunk=chunk_index,  # v2.1 format
+                episode_index=DEFAULT_FILE_INDEX,  # v2.1 format
+                chunk_index=chunk_index,  # v3 format
+                file_index=DEFAULT_FILE_INDEX,  # v3 format
             )
             chunk_files["videos"][video_key] = dataset_root / video_path
 
         return chunk_files
 
-    def get_episode_files(self, episode_index: int, chunk_index: int, dataset_root: Path) -> dict:
+    def get_episode_files(
+        self, episode_index: int, chunk_index: int, dataset_root: Path
+    ) -> dict:
         """
         Get file paths for a specific episode within a chunk.
+
         Args:
             episode_index: The episode index (e.g., 0 for file-000, 1 for file-001)
             chunk_index: The chunk index (e.g., 0 for chunk-000)
             dataset_root: Root directory of the dataset
+
         Returns:
             Dictionary with:
             {
@@ -129,9 +155,12 @@ class DatasetInfo:
         episode_files = {}
 
         # Get parquet file path using episode_index as file_index
+        # Support both v2.1 and v3 naming conventions
         parquet_path = self.data_path_template.format(
-            chunk_index=chunk_index,
-            file_index=episode_index
+            episode_chunk=chunk_index,  # v2.1 format
+            episode_index=episode_index,  # v2.1 format
+            chunk_index=chunk_index,  # v3 format
+            file_index=episode_index,  # v3 format
         )
         episode_files["parquet"] = dataset_root / parquet_path
 
@@ -139,10 +168,13 @@ class DatasetInfo:
         episode_files["videos"] = {}
 
         for video_key in self.video_keys:
+            # Support both v2.1 and v3 naming conventions
             video_path = self.video_path_template.format(
                 video_key=video_key,
-                chunk_index=chunk_index,
-                file_index=episode_index
+                episode_chunk=chunk_index,  # v2.1 format
+                episode_index=episode_index,  # v2.1 format
+                chunk_index=chunk_index,  # v3 format
+                file_index=episode_index,  # v3 format
             )
             episode_files["videos"][video_key] = dataset_root / video_path
 
@@ -168,7 +200,7 @@ class DatasetInfo:
         Returns:
             Video codec (e.g., "av1", "h264")
         """
-        #### Commented out for testing ### 
+        #### Commented out for testing ###
 
         # features = self.data.get("features", {})
         # video_info = features.get(video_key, {})

--- a/lerobot2mcap/dataset_info.py
+++ b/lerobot2mcap/dataset_info.py
@@ -108,6 +108,46 @@ class DatasetInfo:
 
         return chunk_files
 
+    def get_episode_files(self, episode_index: int, chunk_index: int, dataset_root: Path) -> dict:
+        """
+        Get file paths for a specific episode within a chunk.
+        Args:
+            episode_index: The episode index (e.g., 0 for file-000, 1 for file-001)
+            chunk_index: The chunk index (e.g., 0 for chunk-000)
+            dataset_root: Root directory of the dataset
+        Returns:
+            Dictionary with:
+            {
+                "parquet": Path to parquet file,
+                "videos": {
+                    "observation.images.front": Path to video file,
+                    "observation.images.external": Path to video file,
+                    ...
+                }
+            }
+        """
+        episode_files = {}
+
+        # Get parquet file path using episode_index as file_index
+        parquet_path = self.data_path_template.format(
+            chunk_index=chunk_index,
+            file_index=episode_index
+        )
+        episode_files["parquet"] = dataset_root / parquet_path
+
+        # Get video file paths using episode_index as file_index
+        episode_files["videos"] = {}
+
+        for video_key in self.video_keys:
+            video_path = self.video_path_template.format(
+                video_key=video_key,
+                chunk_index=chunk_index,
+                file_index=episode_index
+            )
+            episode_files["videos"][video_key] = dataset_root / video_path
+
+        return episode_files
+
     def get_total_chunks(self) -> int:
         """
         Get total number of chunks in the dataset.

--- a/lerobot2mcap/dataset_info.py
+++ b/lerobot2mcap/dataset_info.py
@@ -131,27 +131,35 @@ class DatasetInfo:
         """
         chunk_files = {}
 
-        # Get parquet file path using property (checks info.json with fallback)
-        # Support both v2.1 and v3 naming conventions
-        parquet_path = self.data_path_template.format(
-            episode_chunk=chunk_index,  # v2.1 format
-            episode_index=DEFAULT_FILE_INDEX,  # v2.1 format
-            chunk_index=chunk_index,  # v3 format
-            file_index=DEFAULT_FILE_INDEX,  # v3 format
-        )
+        # Determine format parameters based on dataset version
+        version = self.get_codebase_version()
+        if version.startswith("v2"):
+            # v2.1 format: use episode_chunk and episode_index, null out v3 params
+            format_params = {
+                "episode_chunk": chunk_index,
+                "episode_index": DEFAULT_FILE_INDEX,
+                "chunk_index": None,
+                "file_index": None,
+            }
+        else:
+            # v3.0+ format: use chunk_index and file_index, null out v2 params
+            format_params = {
+                "episode_chunk": None,
+                "episode_index": None,
+                "chunk_index": chunk_index,
+                "file_index": DEFAULT_FILE_INDEX,
+            }
+
+        # Get parquet file path
+        parquet_path = self.data_path_template.format(**format_params)
         chunk_files["parquet"] = dataset_root / parquet_path
 
-        # Get video file paths using property (checks info.json with fallback)
+        # Get video file paths
         chunk_files["videos"] = {}
-
         for video_key in self.video_keys:
-            # Support both v2.1 and v3 naming conventions
             video_path = self.video_path_template.format(
                 video_key=video_key,
-                episode_chunk=chunk_index,  # v2.1 format
-                episode_index=DEFAULT_FILE_INDEX,  # v2.1 format
-                chunk_index=chunk_index,  # v3 format
-                file_index=DEFAULT_FILE_INDEX,  # v3 format
+                **format_params,
             )
             chunk_files["videos"][video_key] = dataset_root / video_path
 
@@ -181,27 +189,35 @@ class DatasetInfo:
         """
         episode_files = {}
 
-        # Get parquet file path using episode_index as file_index
-        # Support both v2.1 and v3 naming conventions
-        parquet_path = self.data_path_template.format(
-            episode_chunk=chunk_index,  # v2.1 format
-            episode_index=episode_index,  # v2.1 format
-            chunk_index=chunk_index,  # v3 format
-            file_index=episode_index,  # v3 format
-        )
+        # Determine format parameters based on dataset version
+        version = self.get_codebase_version()
+        if version.startswith("v2"):
+            # v2.1 format: use episode_chunk and episode_index, null out v3 params
+            format_params = {
+                "episode_chunk": chunk_index,
+                "episode_index": episode_index,
+                "chunk_index": None,
+                "file_index": None,
+            }
+        else:
+            # v3.0+ format: use chunk_index and file_index, null out v2 params
+            format_params = {
+                "episode_chunk": None,
+                "episode_index": None,
+                "chunk_index": chunk_index,
+                "file_index": episode_index,
+            }
+
+        # Get parquet file path
+        parquet_path = self.data_path_template.format(**format_params)
         episode_files["parquet"] = dataset_root / parquet_path
 
-        # Get video file paths using episode_index as file_index
+        # Get video file paths
         episode_files["videos"] = {}
-
         for video_key in self.video_keys:
-            # Support both v2.1 and v3 naming conventions
             video_path = self.video_path_template.format(
                 video_key=video_key,
-                episode_chunk=chunk_index,  # v2.1 format
-                episode_index=episode_index,  # v2.1 format
-                chunk_index=chunk_index,  # v3 format
-                file_index=episode_index,  # v3 format
+                **format_params,
             )
             episode_files["videos"][video_key] = dataset_root / video_path
 

--- a/lerobot2mcap/dataset_info.py
+++ b/lerobot2mcap/dataset_info.py
@@ -3,20 +3,15 @@ Parses the info.json file to extract metadata about the dataset,"""
 
 import json
 import logging
+import math
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-# Default values for dataset metadata
-DEFAULT_FPS = 30
-DEFAULT_CODEC = "h264"
+# Official LeRobot defaults (from lerobot.datasets.utils)
+DEFAULT_CHUNK_SIZE = 1000  # Max number of episodes per chunk
+DEFAULT_CODEC = "h264"  # Default video codec if not specified
 DEFAULT_FILE_INDEX = 0  # First file in a chunk
-DEFAULT_DATA_PATH_TEMPLATE = (
-    "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet"
-)
-DEFAULT_VIDEO_PATH_TEMPLATE = (
-    "videos/{video_key}/chunk-{chunk_index:03d}/file-{file_index:03d}.mp4"
-)
 
 
 class DatasetInfo:
@@ -57,9 +52,18 @@ class DatasetInfo:
         Extract video keys from features.
         Video features have dtype="video" in info.json.
         Example: "observation.images.front", "observation.images.external"
+
+        Raises:
+            KeyError: If 'features' field is missing from info.json
         """
+        if "features" not in self.data:
+            raise KeyError(
+                f"Required field 'features' not found in {self.info_json_path}. "
+                "This field is required in LeRobot datasets."
+            )
+
         video_keys = []
-        features = self.data.get("features", {})
+        features = self.data["features"]
 
         for feature_name, feature_info in features.items():
             if isinstance(feature_info, dict) and feature_info.get("dtype") == "video":
@@ -71,17 +75,40 @@ class DatasetInfo:
     def data_path_template(self) -> str:
         """
         Get the data (parquet) path template from dataset metadata.
-        Checking data_path value for robustness - falls back to default if not in info.json.
+
+        Returns:
+            Path template string (e.g., "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet")
+
+        Raises:
+            KeyError: If 'data_path' field is missing from info.json
         """
-        return self.data.get("data_path", DEFAULT_DATA_PATH_TEMPLATE)
+        if "data_path" not in self.data:
+            raise KeyError(
+                f"Required field 'data_path' not found in {self.info_json_path}. "
+                "This field is required in LeRobot datasets."
+            )
+        return self.data["data_path"]
 
     @property
     def video_path_template(self) -> str:
         """
         Get the video path template from dataset metadata.
-        Checking video_path value for robustness - falls back to default if not in info.json.
+
+        Returns:
+            Path template string (e.g., "videos/{video_key}/chunk-{chunk_index:03d}/file-{file_index:03d}.mp4")
+
+        Raises:
+            KeyError: If 'video_path' field is missing from info.json when video features exist
         """
-        return self.data.get("video_path", DEFAULT_VIDEO_PATH_TEMPLATE)
+        if "video_path" not in self.data:
+            if self.video_keys:  # Only required if dataset has video features
+                raise KeyError(
+                    f"Required field 'video_path' not found in {self.info_json_path}. "
+                    "This field is required when the dataset contains video features."
+                )
+            # Return empty string if no videos (though this shouldn't be called in that case)
+            return ""
+        return self.data["video_path"]
 
     def get_chunk_files(self, chunk_index: int, dataset_root: Path) -> dict:
         """
@@ -183,14 +210,117 @@ class DatasetInfo:
     def get_total_chunks(self) -> int:
         """
         Get total number of chunks in the dataset.
-        Assumes single chunk (chunk-000) structure for LeRobot datasets.
-        Keeping function here as a placeholder for future multi-chunk support if necessary.
+
+        Calculates from metadata using: ceil(total_episodes / chunks_size)
+        where chunks_size is the maximum number of episodes per chunk.
+
+        Returns:
+            Number of chunks in the dataset (minimum 1)
+
+        Raises:
+            KeyError: If 'total_episodes' field is missing from info.json
         """
+        if "total_episodes" not in self.data:
+            raise KeyError(
+                f"Required field 'total_episodes' not found in {self.info_json_path}. "
+                "This field is required in LeRobot datasets."
+            )
+
+        total_episodes = self.data["total_episodes"]
+        # chunks_size has an official default value
+        chunks_size = self.data.get("chunks_size", DEFAULT_CHUNK_SIZE)
+
+        if total_episodes > 0 and chunks_size > 0:
+            return math.ceil(total_episodes / chunks_size)
+
+        # Fallback to 1 chunk if calculation not possible
         return 1
 
     def get_fps(self) -> int:
-        """Get frames per second from dataset info."""
-        return self.data.get("fps", DEFAULT_FPS)
+        """
+        Get frames per second from dataset info.
+
+        Returns:
+            Frames per second as an integer
+
+        Raises:
+            KeyError: If 'fps' field is missing from info.json
+        """
+        if "fps" not in self.data:
+            raise KeyError(
+                f"Required field 'fps' not found in {self.info_json_path}. "
+                "This field is required in LeRobot datasets."
+            )
+        return self.data["fps"]
+
+    def get_codebase_version(self) -> str:
+        """
+        Get the LeRobot codebase version (dataset format version).
+
+        This indicates the schema version of the dataset and parquet files.
+        Examples: "v2.0", "v2.1", "v3.0"
+
+        Returns:
+            Codebase version string
+
+        Raises:
+            KeyError: If 'codebase_version' field is missing from info.json
+        """
+        if "codebase_version" not in self.data:
+            raise KeyError(
+                f"Required field 'codebase_version' not found in {self.info_json_path}. "
+                "This field is required in LeRobot datasets to identify the dataset format version."
+            )
+        return self.data["codebase_version"]
+
+    def get_writer_format(self) -> str:
+        """
+        Get MCAP writer format from dataset metadata.
+
+        Returns:
+            Writer format (e.g., "ros1", "ros2", "json", "protobuf")
+            Defaults to "ros2" for LeRobot datasets.
+        """
+        return self.data.get("writer_format", "ros2")
+
+    def get_video_codec(self, video_key: str) -> str:
+        """
+        Get video codec for a specific video stream.
+
+        Looks up codec in features metadata for the given video_key.
+        Falls back to DEFAULT_CODEC if not specified.
+
+        Args:
+            video_key: The video key (e.g., "observation.images.front")
+
+        Returns:
+            Video codec (e.g., "h264", "h265", "vp9", "av1")
+
+        Raises:
+            KeyError: If 'features' field is missing from info.json
+        """
+        if "features" not in self.data:
+            raise KeyError(
+                f"Required field 'features' not found in {self.info_json_path}. "
+                "This field is required in LeRobot datasets."
+            )
+
+        features = self.data["features"]
+        if video_key in features:
+            video_info = features[video_key]
+            if isinstance(video_info, dict):
+                # Check in the 'info' sub-dict first (LeRobot v2.x/v3.x format)
+                if "info" in video_info and isinstance(video_info["info"], dict):
+                    codec = video_info["info"].get("video.codec", DEFAULT_CODEC)
+                else:
+                    codec = video_info.get("codec", DEFAULT_CODEC)
+
+                # Validate codec is one of the supported formats
+                if codec in ("h264", "h265", "vp9", "av1"):
+                    return codec
+
+        # Fallback to default codec
+        return DEFAULT_CODEC
 
     def get_video_frame_id(self, video_key: str) -> str:
         """
@@ -206,12 +336,26 @@ class DatasetInfo:
         return f"{camera_name}_camera"
 
     def get_total_episodes(self) -> int:
-        """Get total number of episodes in the dataset."""
-        return self.data.get("total_episodes", 0)
+        """
+        Get total number of episodes in the dataset.
+
+        Returns:
+            Total number of episodes as an integer
+
+        Raises:
+            KeyError: If 'total_episodes' field is missing from info.json
+        """
+        if "total_episodes" not in self.data:
+            raise KeyError(
+                f"Required field 'total_episodes' not found in {self.info_json_path}. "
+                "This field is required in LeRobot datasets."
+            )
+        return self.data["total_episodes"]
 
     def __repr__(self) -> str:
         return (
-            f"DatasetInfo(episodes={self.get_total_episodes()}, "
+            f"DatasetInfo(version={self.get_codebase_version()}, "
+            f"episodes={self.get_total_episodes()}, "
             f"chunks={self.get_total_chunks()}, "
             f"fps={self.get_fps()}, "
             f"videos={len(self.video_keys)})"

--- a/lerobot2mcap/dataset_info.py
+++ b/lerobot2mcap/dataset_info.py
@@ -7,6 +7,13 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+# Default values for dataset metadata
+DEFAULT_FPS = 30
+DEFAULT_CODEC = "h264"
+DEFAULT_FILE_INDEX = 0  # First file in a chunk
+DEFAULT_DATA_PATH_TEMPLATE = "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet"
+DEFAULT_VIDEO_PATH_TEMPLATE = "videos/{video_key}/chunk-{chunk_index:03d}/file-{file_index:03d}.mp4"
+
 
 class DatasetInfo:
     """Parses and holds LeRobot dataset metadata from info.json."""
@@ -14,7 +21,6 @@ class DatasetInfo:
     def __init__(self, info_json_path: Path):
         """
         Initialize DatasetInfo by parsing info.json.
-
         Args:
             info_json_path: Path to the info.json file (usually in meta/info.json)
         """
@@ -35,7 +41,6 @@ class DatasetInfo:
     def _extract_video_keys(self) -> list[str]:
         """
         Extract video keys from features.
-
         Video features have dtype="video" in info.json.
         Example: "observation.images.front", "observation.images.external"
         """
@@ -48,14 +53,28 @@ class DatasetInfo:
 
         return video_keys
 
+    @property
+    def data_path_template(self) -> str:
+        """
+        Get the data (parquet) path template from dataset metadata.
+        Checking data_path value for robustness - falls back to default if not in info.json.
+        """
+        return self.data.get("data_path", DEFAULT_DATA_PATH_TEMPLATE)
+
+    @property
+    def video_path_template(self) -> str:
+        """
+        Get the video path template from dataset metadata.
+        Checking video_path value for robustness - falls back to default if not in info.json.
+        """
+        return self.data.get("video_path", DEFAULT_VIDEO_PATH_TEMPLATE)
+
     def get_chunk_files(self, chunk_index: int, dataset_root: Path) -> dict:
         """
         Get file paths for a specific chunk.
-
         Args:
             chunk_index: The chunk index (e.g., 0 for chunk-000)
             dataset_root: Root directory of the dataset
-
         Returns:
             Dictionary with:
             {
@@ -69,80 +88,68 @@ class DatasetInfo:
         """
         chunk_files = {}
 
-        # Get parquet file path
-        data_path_template = self.data.get("data_path", "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet")
-        # For now, assume file_index is always 000 within a chunk
-        parquet_path = data_path_template.format(chunk_index=chunk_index, file_index=0)
+        # Get parquet file path using property (checks info.json with fallback)
+        parquet_path = self.data_path_template.format(
+            chunk_index=chunk_index,
+            file_index=DEFAULT_FILE_INDEX
+        )
         chunk_files["parquet"] = dataset_root / parquet_path
 
-        # Get video file paths
-        video_path_template = self.data.get("video_path", "videos/{video_key}/chunk-{chunk_index:03d}/file-{file_index:03d}.mp4")
+        # Get video file paths using property (checks info.json with fallback)
         chunk_files["videos"] = {}
 
         for video_key in self.video_keys:
-            video_path = video_path_template.format(
+            video_path = self.video_path_template.format(
                 video_key=video_key,
                 chunk_index=chunk_index,
-                file_index=0
+                file_index=DEFAULT_FILE_INDEX
             )
             chunk_files["videos"][video_key] = dataset_root / video_path
 
         return chunk_files
 
-
-# TO DO - Not sure if this is doing the correct thing yet 
     def get_total_chunks(self) -> int:
         """
-        Calculate total number of chunks in the dataset.
-
-        Uses chunks_size and total_frames to determine chunk count.
+        Get total number of chunks in the dataset.
+        Assumes single chunk (chunk-000) structure for LeRobot datasets.
+        Keeping function here as a placeholder for future multi-chunk support if necessary.
         """
-        chunks_size = self.data.get("chunks_size", 1000)
-        total_frames = self.data.get("total_frames", 0)
-
-        if total_frames == 0:
-            return 0
-
-        # Calculate number of chunks (ceiling division)
-        return (total_frames + chunks_size - 1) // chunks_size
+        return 1
 
     def get_fps(self) -> int:
         """Get frames per second from dataset info."""
-        return self.data.get("fps", 30)
+        return self.data.get("fps", DEFAULT_FPS)
 
     def get_video_codec(self, video_key: str) -> str:
         """
         Get video codec for a specific video stream.
-
         Args:
             video_key: The video key (e.g., "observation.images.front")
-
         Returns:
             Video codec (e.g., "av1", "h264")
         """
-        features = self.data.get("features", {})
-        video_info = features.get(video_key, {})
+        #### Commented out for testing ### 
 
-        if isinstance(video_info, dict):
-            codec = video_info.get("info", {}).get("video.codec", "h264")
-            return codec
+        # features = self.data.get("features", {})
+        # video_info = features.get(video_key, {})
 
-        return "h264"  # Default fallback
+        # if isinstance(video_info, dict):
+        #     codec = video_info.get("info", {}).get("video.codec", DEFAULT_CODEC)
+        #     return codec
+
+        return DEFAULT_CODEC
 
     def get_video_frame_id(self, video_key: str) -> str:
         """
         Generate frame_id for a video stream.
-
         Args:
             video_key: The video key (e.g., "observation.images.front")
-
         Returns:
             Frame ID (e.g., "front_camera")
         """
         # Extract the last part of the video key as frame_id
         # "observation.images.front" -> "front_camera"
-        parts = video_key.split(".")
-        camera_name = parts[-1] if parts else "camera"
+        camera_name = video_key.split(".")[-1] if "." in video_key else "camera"
         return f"{camera_name}_camera"
 
     def get_total_episodes(self) -> int:

--- a/lerobot2mcap/dataset_info.py
+++ b/lerobot2mcap/dataset_info.py
@@ -192,25 +192,6 @@ class DatasetInfo:
         """Get frames per second from dataset info."""
         return self.data.get("fps", DEFAULT_FPS)
 
-    def get_video_codec(self, video_key: str) -> str:
-        """
-        Get video codec for a specific video stream.
-        Args:
-            video_key: The video key (e.g., "observation.images.front")
-        Returns:
-            Video codec (e.g., "av1", "h264")
-        """
-        #### Commented out for testing ###
-
-        # features = self.data.get("features", {})
-        # video_info = features.get(video_key, {})
-
-        # if isinstance(video_info, dict):
-        #     codec = video_info.get("info", {}).get("video.codec", DEFAULT_CODEC)
-        #     return codec
-
-        return DEFAULT_CODEC
-
     def get_video_frame_id(self, video_key: str) -> str:
         """
         Generate frame_id for a video stream.

--- a/lerobot2mcap/dataset_info.py
+++ b/lerobot2mcap/dataset_info.py
@@ -1,0 +1,158 @@
+"""Dataset information parser for LeRobot datasets.
+Parses the info.json file to extract metadata about the dataset,"""
+
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class DatasetInfo:
+    """Parses and holds LeRobot dataset metadata from info.json."""
+
+    def __init__(self, info_json_path: Path):
+        """
+        Initialize DatasetInfo by parsing info.json.
+
+        Args:
+            info_json_path: Path to the info.json file (usually in meta/info.json)
+        """
+        self.info_json_path = info_json_path
+        self.data = self._parse_info_json()
+        self.video_keys = self._extract_video_keys()
+        logger.info(f"Loaded dataset info from {info_json_path}")
+        logger.info(f"Found {len(self.video_keys)} video streams: {self.video_keys}")
+
+    def _parse_info_json(self) -> dict:
+        """Parse the info.json file."""
+        if not self.info_json_path.exists():
+            raise FileNotFoundError(f"info.json not found at {self.info_json_path}")
+
+        with open(self.info_json_path) as f:
+            return json.load(f)
+
+    def _extract_video_keys(self) -> list[str]:
+        """
+        Extract video keys from features.
+
+        Video features have dtype="video" in info.json.
+        Example: "observation.images.front", "observation.images.external"
+        """
+        video_keys = []
+        features = self.data.get("features", {})
+
+        for feature_name, feature_info in features.items():
+            if isinstance(feature_info, dict) and feature_info.get("dtype") == "video":
+                video_keys.append(feature_name)
+
+        return video_keys
+
+    def get_chunk_files(self, chunk_index: int, dataset_root: Path) -> dict:
+        """
+        Get file paths for a specific chunk.
+
+        Args:
+            chunk_index: The chunk index (e.g., 0 for chunk-000)
+            dataset_root: Root directory of the dataset
+
+        Returns:
+            Dictionary with:
+            {
+                "parquet": Path to parquet file,
+                "videos": {
+                    "observation.images.front": Path to video file,
+                    "observation.images.external": Path to video file,
+                    ...
+                }
+            }
+        """
+        chunk_files = {}
+
+        # Get parquet file path
+        data_path_template = self.data.get("data_path", "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet")
+        # For now, assume file_index is always 000 within a chunk
+        parquet_path = data_path_template.format(chunk_index=chunk_index, file_index=0)
+        chunk_files["parquet"] = dataset_root / parquet_path
+
+        # Get video file paths
+        video_path_template = self.data.get("video_path", "videos/{video_key}/chunk-{chunk_index:03d}/file-{file_index:03d}.mp4")
+        chunk_files["videos"] = {}
+
+        for video_key in self.video_keys:
+            video_path = video_path_template.format(
+                video_key=video_key,
+                chunk_index=chunk_index,
+                file_index=0
+            )
+            chunk_files["videos"][video_key] = dataset_root / video_path
+
+        return chunk_files
+
+
+# TO DO - Not sure if this is doing the correct thing yet 
+    def get_total_chunks(self) -> int:
+        """
+        Calculate total number of chunks in the dataset.
+
+        Uses chunks_size and total_frames to determine chunk count.
+        """
+        chunks_size = self.data.get("chunks_size", 1000)
+        total_frames = self.data.get("total_frames", 0)
+
+        if total_frames == 0:
+            return 0
+
+        # Calculate number of chunks (ceiling division)
+        return (total_frames + chunks_size - 1) // chunks_size
+
+    def get_fps(self) -> int:
+        """Get frames per second from dataset info."""
+        return self.data.get("fps", 30)
+
+    def get_video_codec(self, video_key: str) -> str:
+        """
+        Get video codec for a specific video stream.
+
+        Args:
+            video_key: The video key (e.g., "observation.images.front")
+
+        Returns:
+            Video codec (e.g., "av1", "h264")
+        """
+        features = self.data.get("features", {})
+        video_info = features.get(video_key, {})
+
+        if isinstance(video_info, dict):
+            codec = video_info.get("info", {}).get("video.codec", "h264")
+            return codec
+
+        return "h264"  # Default fallback
+
+    def get_video_frame_id(self, video_key: str) -> str:
+        """
+        Generate frame_id for a video stream.
+
+        Args:
+            video_key: The video key (e.g., "observation.images.front")
+
+        Returns:
+            Frame ID (e.g., "front_camera")
+        """
+        # Extract the last part of the video key as frame_id
+        # "observation.images.front" -> "front_camera"
+        parts = video_key.split(".")
+        camera_name = parts[-1] if parts else "camera"
+        return f"{camera_name}_camera"
+
+    def get_total_episodes(self) -> int:
+        """Get total number of episodes in the dataset."""
+        return self.data.get("total_episodes", 0)
+
+    def __repr__(self) -> str:
+        return (
+            f"DatasetInfo(episodes={self.get_total_episodes()}, "
+            f"chunks={self.get_total_chunks()}, "
+            f"fps={self.get_fps()}, "
+            f"videos={len(self.video_keys)})"
+        )


### PR DESCRIPTION
## What does this PR do?
Adds automatic detection and support for multiple LeRobot dataset format versions, eliminating the need for manual configuration or separate conversion tools.

#### Key Changes:
🔄 Cross-version support: Supports LeRobot v2.0, v2.1 dataset formats automatically, with partial support for v3.0
🎯 Smart detection: Reads path templates from meta/info.json to determine format 
📦 Dual naming conventions: Supports both episode_chunk/episode_index (v2.x) and chunk_index/file_index (v3) 
🔧 Unified workflow: Single command converts any version without format flags 
📥 Integrated download: download command now automatically converts after downloading 
🪵 Log file support: Reinstated full .log file attachment functionality 
✅ Dev tooling: Added pytest to dev dependencies
⚠️ Future work: Lerobot dataset v3.0 file splitting into individual episodes remains outstanding, for a future PR

#### Format Differences:
v2.x: data/chunk-{episode_chunk:03d}/episode_{episode_index:06d}.parquet
v3: data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet

#### Updated Files:
config_generator.py: Added dual placeholder support in _format_file_pattern() and _format_episode_pattern()
dataset_info.py: Enhanced get_episode_files() and get_chunk_files() to provide both naming conventions
__init__.py: Unified download+convert workflow
README.md: Documented format differences and cross-compatibility

- [X] New feature (multi-format support)
- [ ]  Bug fix (JSON date conversion)
- [ ] Breaking change
- [X] Documentation

Closes #1 

## Checklist 

- [X]  Tests pass (uv run pytest)
- [X] Linting passes (uv run ruff check . && uv run ruff format .)
- [X] Added comprehensive format tests
- [X] Updated README with installation options